### PR TITLE
Jest connected component test pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-scripts": "1.0.14",
     "react-test-renderer": "^16.3.1",
     "redux": "^3.7.2",
+    "redux-mock-store": "^1.5.1",
     "redux-thunk": "^2.2.0",
     "swiper": "^4.2.0"
   },

--- a/src/containers/HomePage.js
+++ b/src/containers/HomePage.js
@@ -11,31 +11,28 @@ import {
   handleUpdateBodyClass
 } from '../actions';
 
-class HomePage extends Component {
+export class HomePage extends Component {
   componentDidMount() {
-    document.getElementById('page').classList.remove('standard-margin');
-    this.props.dispatch(handleUpdateBodyClass('landing-page'));
+    const page = document.getElementById('page');
+    if (page) {
+      page.classList.remove('standard-margin');
+    }
+    this.props.handleUpdateBodyClass('landing-page');
 
     // Dispatch redux thunk action creators to grab async api data
-    this.props.dispatch(
-      fetchCarouselItems(
-        '/json/mock/recently-digitized-items.js',
-        CAROUSELS.RECENTLY_DIGITIZED_ITEMS
-      )
+    this.props.fetchCarouselItems(
+      '/json/mock/recently-digitized-items.js',
+      CAROUSELS.RECENTLY_DIGITIZED_ITEMS
     );
 
-    this.props.dispatch(
-      fetchCarouselItems(
-        '/json/mock/recently-digitized-collections.js',
-        CAROUSELS.RECENTLY_DIGITIZED_COLLECTIONS
-      )
+    this.props.fetchCarouselItems(
+      '/json/mock/recently-digitized-collections.js',
+      CAROUSELS.RECENTLY_DIGITIZED_COLLECTIONS
     );
 
-    this.props.dispatch(
-      fetchCarouselItems(
-        '/json/mock/photography-collections.js',
-        CAROUSELS.PHOTOGRAPHY_COLLECTIONS
-      )
+    this.props.fetchCarouselItems(
+      '/json/mock/photography-collections.js',
+      CAROUSELS.PHOTOGRAPHY_COLLECTIONS
     );
   }
 
@@ -83,4 +80,10 @@ const mapStateToProps = state => ({
   carousels: state.carousels
 });
 
-export default connect(mapStateToProps)(HomePage);
+const mapDispatchToProps = dispatch => ({
+  handleUpdateBodyClass: bodyClass =>
+    dispatch(handleUpdateBodyClass(bodyClass)),
+  fetchCarouselItems: (url, title) => dispatch(fetchCarouselItems(url, title))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(HomePage);

--- a/src/containers/HomePage.test.js
+++ b/src/containers/HomePage.test.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ConnectedApp, { HomePage } from './HomePage';
+import configureMockStore from 'redux-mock-store';
+const mockStore = configureMockStore();
+
+import HeroSection from '../components/Home/HeroSection';
+import HeroSecondarySection from '../components/Home/HeroSecondarySection';
+import CarouselSection from '../components/CarouselSection';
+
+const initialState = {
+  carousels: {
+    recentlyDigitizedItems: {
+      items: [
+        {
+          title: 'Mock Title',
+          url: 'https://test.com'
+        }
+      ]
+    }
+  }
+};
+
+describe('HomePage (not connected) Component', () => {
+  let wrapper;
+  const mockFetchCarouselItems = jest.fn();
+  const mockHandleUpdateBodyClass = jest.fn();
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <HomePage
+        carousels={initialState}
+        handleUpdateBodyClass={mockHandleUpdateBodyClass}
+        fetchCarouselItems={mockFetchCarouselItems}
+      />
+    );
+  });
+
+  afterEach(() => {
+    mockFetchCarouselItems.mockClear();
+    mockHandleUpdateBodyClass.mockClear();
+  });
+
+  it('should call handleUpdateBodyClass() actionCreator mapped to props', () => {
+    expect(mockHandleUpdateBodyClass.mock.calls.length).toBe(1);
+  });
+
+  it('should call fetchCarouselItems() actionCreator mapped to props', () => {
+    expect(mockFetchCarouselItems.mock.calls.length).toBe(3);
+  });
+
+  it('should render HeroSection', () => {
+    expect(wrapper.find(HeroSection)).toHaveLength(1);
+  });
+
+  it('should render HeroSecondarySection', () => {
+    expect(wrapper.find(HeroSecondarySection)).toHaveLength(1);
+  });
+
+  it('should render three CarouselSections', () => {
+    expect(wrapper.find(CarouselSection)).toHaveLength(3);
+  });
+});
+
+describe('HomePage Container Component', () => {
+  let wrapper, store;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+    wrapper = shallow(<ConnectedApp store={store} />);
+  });
+
+  it('renders without crashing', () => {
+    expect(wrapper).toBeDefined();
+  });
+
+  it('renders carousel from mapStatetoProps', () => {
+    expect(wrapper.prop('carousels')).toBeDefined();
+  });
+
+  it('renders mapDispatchToProps props', () => {
+    expect(wrapper.prop('fetchCarouselItems')).toBeDefined();
+    expect(wrapper.prop('handleUpdateBodyClass')).toBeDefined();
+  });
+});

--- a/src/containers/Layout.test.js
+++ b/src/containers/Layout.test.js
@@ -10,32 +10,34 @@ it('renders without crashing', () => {
   shallow(<Layout />);
 });
 
-it('renders Header component', () => {
-  const wrapper = shallow(<Layout />);
-  expect(wrapper.find(Header)).toHaveLength(1);
-});
+describe('Layout Component', () => {
+  let wrapper = null;
 
-it('renders Nav component', () => {
-  const wrapper = shallow(<Layout />);
-  expect(wrapper.find(Nav)).toHaveLength(1);
-});
+  beforeEach(() => {
+    wrapper = shallow(<Layout />);
+  });
 
-it('renders GlobalSearch component', () => {
-  const wrapper = shallow(<Layout />);
-  expect(wrapper.find(GlobalSearch)).toHaveLength(1);
-});
+  it('renders Header component', () => {
+    expect(wrapper.find(Header)).toHaveLength(1);
+  });
 
-it('renders the <main> html element', () => {
-  const wrapper = shallow(<Layout />);
-  expect(wrapper.find('main#main-content')).toHaveLength(1);
-});
+  it('renders Nav component', () => {
+    expect(wrapper.find(Nav)).toHaveLength(1);
+  });
 
-it('renders Switch routing component', () => {
-  const wrapper = shallow(<Layout />);
-  expect(wrapper.find(Switch)).toHaveLength(1);
-});
+  it('renders GlobalSearch component', () => {
+    expect(wrapper.find(GlobalSearch)).toHaveLength(1);
+  });
 
-it('renders Route routing components', () => {
-  const wrapper = shallow(<Layout />);
-  expect(wrapper.find(Route).length).toBeGreaterThanOrEqual(1);
+  it('renders the <main> html element', () => {
+    expect(wrapper.find('main#main-content')).toHaveLength(1);
+  });
+
+  it('renders Switch routing component', () => {
+    expect(wrapper.find(Switch)).toHaveLength(1);
+  });
+
+  it('renders Route routing components', () => {
+    expect(wrapper.find(Route).length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4501,6 +4501,10 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -6192,6 +6196,12 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-mock-store@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.1.tgz#fca4335392e66605420b5559fe02fc5b8bb6d63c"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This is an example of a Jest test for splitting testing of a higher order, connected container component, along with it's presentational component.   React Redux's `connect` utility injects some behind the scenes magic to account for in connected component testing.  This is a first approach based off what seems to be best practices at the moment. 