### PR TITLE
Update homepage Works carousel to use Solr IIIF urls instead of fetch…

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -21,8 +21,19 @@ class Carousel extends Component {
     this.initializeSwiper = this.initializeSwiper.bind(this);
   }
 
-  componentDidUpdate() {
+  // Dynamic carousels added by keyword may already have their items data filled when they enter here.
+  componentDidMount() {
     if (this.props.items.length > 0) {
+      this.initializeSwiper();
+    }
+  }
+
+  // Some carousels may be declared in initial render, when their items have yet to be filled.
+  componentDidUpdate(prevProps) {
+    const { items } = this.props;
+    const prevItems = prevProps.items;
+
+    if (items.length > 0 && items.length !== prevItems.length) {
       this.initializeSwiper();
     }
   }

--- a/src/components/CarouselSection.test.js
+++ b/src/components/CarouselSection.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CarouselSection from './CarouselSection';
+import Carousel from './Carousel';
+import ErrorSection from './ErrorSection';
+
+let wrapper;
+const sectionTitle = 'Carousel Items Title';
+
+beforeEach(() => {
+  wrapper = shallow(
+    <CarouselSection
+      linkTo=""
+      sectionTitle={sectionTitle}
+      items={[]}
+      slidesPerView={4}
+      error={false}
+    />
+  );
+});
+
+it('renders without crashing', () => {
+  expect(wrapper.length).toEqual(1);
+});
+
+it('should render a single <Carousel /> component', () => {
+  expect(wrapper.find(Carousel)).toHaveLength(1);
+});
+
+it('should render an <ErrorSection /> component if an error object is present', () => {
+  expect(wrapper.find(ErrorSection)).toHaveLength(0);
+
+  wrapper.setProps({ error: { statusText: 'error' } });
+  expect(wrapper.find(ErrorSection)).toHaveLength(1);
+});
+
+it('should render a section title', () => {
+  expect(wrapper.find('h4').text()).toContain(sectionTitle);
+});

--- a/src/containers/HomePage.js
+++ b/src/containers/HomePage.js
@@ -40,7 +40,7 @@ export class HomePage extends Component {
     this.props.handleUpdateBodyClass('landing-page');
   }
 
-  createCarousels() {
+  createAdditionalCarousels() {
     const { carousels } = this.props;
 
     return this.carouselsByKeyword.map(keyword => {
@@ -91,7 +91,7 @@ export class HomePage extends Component {
             slidesPerView={4}
           />
           <HeroSecondarySection heroData={heroSecondaryData} />
-          {this.createCarousels()}
+          {this.createAdditionalCarousels()}
         </section>
       </div>
     );

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -47,3 +47,20 @@ function getIIIFRootUrl(manifest) {
   }
   return iiifRootUrl;
 }
+
+/**
+ * Fetch IIIF manifests for supplied manifest urls
+ * @param  {Array} helperArray An array of objects which delivers an item's id and manifest url
+ * @return {Array} An array of IIIF manifest objects
+ */
+async function getManifests(helperArray) {
+  let promises = [];
+  for (let item of helperArray) {
+    promises.push(fetch(item.manifestUrl).then(response => response.json()));
+  }
+  const manifests = await Promise.all(promises)
+    .then(response => response)
+    .catch(error => console.log(error));
+
+  return manifests;
+}


### PR DESCRIPTION
…ing individual manifests; fix lifecycle bug in swiper initialization.

This pulls the Work IIIF image urls from the Solr document, so the Recently Digitized Items carousel loads much faster.