### PR TITLE
Stub out faceting sidebar for collections item page

### DIFF
--- a/src/components/Collection/Sidebar.js
+++ b/src/components/Collection/Sidebar.js
@@ -1,46 +1,175 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import { Link } from 'react-router-dom';
 
 const Sidebar = props => {
   const { item } = props;
+
   return (
     <div id="sidebar" className="left-sidebar content" tabIndex="-1">
       <div className="box">
         <div id="tab-container">
-          <ul id="tabs" role="tablist">
-            <li role="presentation">
-              <a
-                aria-controls="tab-panel1"
-                href="#tab-panel1"
-                id="tab1"
-                role="tab"
-              >
-                About
-              </a>
-            </li>
-            <li role="presentation">
-              <a
-                aria-controls="tab-panel2"
-                href="#tab-panel2"
-                id="tab2"
-                role="tab"
-              >
-                Filters
-              </a>
-            </li>
-          </ul>
-          <div id="tab-content">
-            <div aria-labelledby="tab1" id="tab-panel1" role="tabpanel">
-              <h3>Collection Description</h3>
-              <p>{item.description}</p>
+          <Tabs selectedTabClassName="active" id="tab-container">
+            <TabList id="tabs" role="tablist">
+              <Tab>About</Tab>
+              <Tab>Filters</Tab>
+            </TabList>
+
+            <div id="tab-content">
+              {/* About tab */}
+              <TabPanel>
+                <h3>Collection Description</h3>
+                <p>{item.description}</p>
+                <h4>Dates / Origin</h4>
+                <ul>
+                  <li>
+                    <Link to="/">Date Created:</Link>
+                  </li>
+                  <li>
+                    <Link to="/">Circa 1916 (Approximate)</Link>
+                  </li>
+                </ul>
+                <h4>Library Locations</h4>
+                <ul>
+                  <li>Northwestern University Transportation Library</li>
+                </ul>
+                <h4>Subjects</h4>
+                <ul>
+                  <li>
+                    <Link to="/">Wilmo Company</Link>
+                  </li>
+                  <li>
+                    <Link to="/">Automobiles</Link>
+                  </li>
+                  <li>
+                    <Link to="/">Parts</Link>
+                  </li>
+                  <li>
+                    <Link to="/">Commercial catalogs</Link>
+                  </li>
+                  <li>
+                    <Link to="/">Automobile factories</Link>
+                  </li>
+                </ul>
+                <h4>Work Types</h4>
+                <ul>
+                  <li>
+                    <Link to="/">Photographs</Link>
+                  </li>
+                </ul>
+              </TabPanel>
+
+              {/* Filter */}
+              <TabPanel>
+                <div className="web-form">
+                  <div className="search-bar-wrapper">
+                    <input type="text" placeholder="Search this collection" />
+                    <span
+                      id="sidebar-search-icon"
+                      className="fa fa-search sidebar-search-icon"
+                    />
+                  </div>
+                </div>
+
+                <div
+                  className="expander expander1"
+                  data-collapse="data-collapse"
+                >
+                  <h3 className="open">Topic</h3>
+                  <ul className="facet-list no-style">
+                    <li className="active">
+                      <span className="close fa fa-close" /> Active filtered
+                      topic (won't display below)
+                    </li>
+                    <li>
+                      <Link to="/">
+                        Public figures <span className="count">104</span>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/">
+                        Sculptures <span className="count">42</span>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/">
+                        Homes and haunts <span className="count">119</span>
+                      </Link>
+                    </li>
+                  </ul>
+
+                  <h3>Name</h3>
+                  <ul className="facet-list no-style">
+                    <li>
+                      <Link to="/">
+                        Napoleon I, Emperor of the French, 1769-1821
+                        <span className="count">632</span>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/">
+                        Franklin, Benjamin, 1706-1790
+                        <span className="count">13</span>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/">
+                        Grant, Ulysses S. (Ulysses Simpson), 1822-1885
+                        <span className="count">87</span>
+                      </Link>
+                    </li>
+                  </ul>
+                  <h3>Collection</h3>
+                  <ul className="facet-list no-style">
+                    <li className="active">
+                      <span className="close fa fa-close" /> This current
+                      collection
+                    </li>
+                    <li>
+                      <Link to="/">Print Collection portrait file</Link>
+                    </li>
+                  </ul>
+                  <h3>Place</h3>
+                  <ul className="facet-list no-style">
+                    <li>
+                      <Link to="/">
+                        New York City
+                        <span className="count">100</span>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/">
+                        Italy
+                        <span className="count">13</span>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/">
+                        St. Helena
+                        <span className="count">276</span>
+                      </Link>
+                    </li>
+                  </ul>
+                  <h3>Genre</h3>
+                  <ul className="facet-list no-style">
+                    <li>
+                      <Link to="/">
+                        Still image
+                        <span className="count">341</span>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/">
+                        Portrait
+                        <span className="count">23</span>
+                      </Link>
+                    </li>
+                  </ul>
+                </div>
+              </TabPanel>
             </div>
-          </div>
-          <div id="tab-content">
-            <div aria-labelledby="tab2" id="tab-panel2" role="tabpanel">
-              <h3>Second Tab Content</h3>
-              <p />
-            </div>
-          </div>
+          </Tabs>
         </div>
       </div>
     </div>
@@ -48,6 +177,7 @@ const Sidebar = props => {
 };
 
 Sidebar.propTypes = {
-  items: PropTypes.array
+  item: PropTypes.object
 };
+
 export default Sidebar;

--- a/src/containers/CollectionContainer.js
+++ b/src/containers/CollectionContainer.js
@@ -14,16 +14,15 @@ export class CollectionContainer extends Component {
   };
 
   componentDidMount() {
-    document.body.className = 'standard-page';
-    const { match } = this.props;
+    const { id } = this.props.match.params;
 
-    if (!match.params.id) {
+    if (!id) {
       return this.setState({
         error: 'Missing id in query param'
       });
     }
-    this.getCollection(match.params.id);
-    this.getCollectionItems(match.params.id);
+    this.getCollection(id);
+    this.getCollectionItems(id);
   }
 
   getCollection(id) {
@@ -65,6 +64,7 @@ export class CollectionContainer extends Component {
     }
     return crumbs;
   }
+
   render() {
     const { collection, error, items } = this.state;
     const breadCrumbData = collection

--- a/src/containers/HomePage.js
+++ b/src/containers/HomePage.js
@@ -21,7 +21,6 @@ export class HomePage extends Component {
     ];
   }
   componentDidMount() {
-    document.body.className = 'landing-page';
     // Dispatch redux thunk action creators to grab async api data
     this.props.fetchCarouselItems(CAROUSELS.RECENTLY_DIGITIZED_ITEMS);
     this.props.fetchCarouselItems(CAROUSELS.RECENTLY_DIGITIZED_COLLECTIONS);
@@ -61,7 +60,7 @@ export class HomePage extends Component {
     } = this.props.carousels;
 
     return (
-      <div>
+      <div className="landing-page">
         <div id="page">
           <main id="main-content" className="content" tabIndex="0">
             <div className="relative-wrapper homepage-hero-wrapper contain-1440">

--- a/src/containers/Layout.js
+++ b/src/containers/Layout.js
@@ -32,9 +32,7 @@ const Layout = () => {
           path="/search-results"
           component={SearchResultsContainer}
         />
-        {/* TODO: Set up this component */}
         <Route exact path="/collections/:id" component={CollectionContainer} />
-
         <Route exact path="/collections" component={AllCollectionsContainer} />
         <Route path="/items/:id" component={ItemDetailContainer} />
         <Route path="/items/" component={ItemsContainer} />


### PR DESCRIPTION
This uses the existing react-tabs library for the faceting sidebar.  Mocked out the About tab and Filter tab, although the filtering tab dropdowns are not working at the moment... don't want to spend too much time on it as it will likely get replaced by elastic search.