### PR TITLE
Make sure ItemDetailContainer state updates when props change

### DIFF
--- a/src/components/ItemDetail/DetailSummary/SummaryListItem.js
+++ b/src/components/ItemDetail/DetailSummary/SummaryListItem.js
@@ -7,7 +7,7 @@ const SummaryListItem = props => {
     <div className="summary-list-item">
       <div className="data-label">{header}</div>
       {items.map((item, index) => (
-        <div key="index" className="data-value">
+        <div key={'index_' + index} className="data-value">
           {item}
         </div>
       ))}

--- a/src/components/ItemDetail/ItemDetailCarousels.js
+++ b/src/components/ItemDetail/ItemDetailCarousels.js
@@ -10,7 +10,9 @@ const ItemDetailCarousels = props => {
 
   const renderCollectionsCarousel = () => {
     const shouldDisplay =
-      Object.keys(item).length > 0 && Object.keys(collectionItems).length > 0;
+      Object.keys(item).length > 0 &&
+      Object.keys(collectionItems).length > 0 &&
+      item.collection.length > 0;
 
     if (!shouldDisplay) {
       return null;

--- a/src/containers/ItemDetailContainer.js
+++ b/src/containers/ItemDetailContainer.js
@@ -20,8 +20,16 @@ export class ItemDetailContainer extends Component {
   };
 
   componentDidMount() {
+    this.displayItem(this.props);
+  }
+
+  UNSAFE_componentWillReceiveProps(props) {
+    this.displayItem(props);
+  }
+
+  displayItem(props) {
     document.body.className = 'standard-page';
-    const { match } = this.props;
+    const { match } = props;
 
     if (!match.params.id) {
       return this.setState({


### PR DESCRIPTION
Fixes #89 

This fix re-renders the item, but we should maybe also add a scroll-to-top or something to make navigation seem more obvious.