### PR TITLE
requested terms link to search results for that term value

### DIFF
--- a/src/components/ItemDetail/ItemDetail.js
+++ b/src/components/ItemDetail/ItemDetail.js
@@ -50,33 +50,49 @@ const ItemDetail = props => {
     { label: 'Alternate Title', value: alternate },
     { label: 'Abstract', value: abstract },
     { label: 'Caption', value: caption },
-    { label: 'Contributor', value: contributor },
-    { label: 'Date', value: date },
+    { label: 'Contributor', value: contributor, facet_value: 'Contributor' },
+    { label: 'Date', value: date, facet_value: 'Date' },
     { label: 'Description', value: description },
-    { label: 'Division', value: admin_set },
-    { label: 'Keyword', value: keyword },
-    { label: 'Language', value: language },
-    { label: 'Location', value: location },
+    { label: 'Division', value: admin_set, facet_value: 'admin_set' },
+    { label: 'Keyword', value: keyword, facet_value: 'Keyword' },
+    { label: 'Language', value: language, facet_value: 'Language' },
+    { label: 'Location', value: location, facet_value: 'Location' },
     { label: 'Provenance', value: provenance },
-    { label: 'Publisher', value: publisher },
-    { label: 'Related Url', value: related_url },
-    { label: 'Rights Holder', value: rights_holder },
-    { label: 'Source', value: source },
-    { label: 'Subject', value: subject },
+    { label: 'Publisher', value: publisher, facet_value: 'Publisher' },
+    { label: 'Related Url', value: related_url, facet_value: 'related_url' },
+    {
+      label: 'Rights Holder',
+      value: rights_holder,
+      facet_value: 'rights_holder'
+    },
+    { label: 'Source', value: source, facet_value: 'source' },
+    { label: 'Subject', value: subject, facet_value: 'subject' },
     { label: 'Rights Statement', value: rights_statement_text },
-    { label: 'Genre', value: genre },
-    { label: 'Physical Description material', value: material },
-    { label: 'Physical Description size', value: size },
-    { label: 'Style Period', value: style_period },
-    { label: 'Technique', value: technique }
+    { label: 'Genre', value: genre, facet_value: 'genre' },
+    {
+      label: 'Physical Description material',
+      value: material,
+      facet_value: 'physical_description'
+    },
+    {
+      label: 'Physical Description size',
+      value: size,
+      facet_value: 'physical_description'
+    },
+    { label: 'Style Period', value: style_period, facet_value: 'style_period' },
+    { label: 'Technique', value: technique, facet_value: 'technique' }
   ];
 
   const findThisItemPanel = [
     { label: 'Accession', value: accession_number },
-    { label: 'Box Name', value: box_name },
-    { label: 'Box Number', value: box_number },
-    { label: 'Folder Name', value: folder_name },
-    { label: 'Folder Number', value: folder_number },
+    { label: 'Box Name', value: box_name, facet_value: 'box_name' },
+    { label: 'Box Number', value: box_number, facet_value: 'box_number' },
+    { label: 'Folder Name', value: folder_name, facet_value: 'folder_name' },
+    {
+      label: 'Folder Number',
+      value: folder_number,
+      facet_value: 'folder_number'
+    },
     { label: 'Call Number', value: call_number },
     { label: 'Catalog Key', value: catalog_key },
     { label: 'Citation', value: bibliographic_citation }
@@ -91,7 +107,7 @@ const ItemDetail = props => {
     { label: 'Title', value: title },
     { label: 'Permalink', value: permalink },
     { label: 'Identifier', value: identifier },
-    { label: 'Licenses', value: license },
+    { label: 'Licenses', value: license, facet_value: 'License' },
     { label: 'Use Statement', value: nul_use_statement }
   ];
 

--- a/src/components/ItemDetail/ItemDetail.js
+++ b/src/components/ItemDetail/ItemDetail.js
@@ -51,36 +51,28 @@ const ItemDetail = props => {
     { label: 'Abstract', value: abstract },
     { label: 'Caption', value: caption },
     { label: 'Contributor', value: contributor, facet_value: 'Contributor' },
-    { label: 'Date', value: date, facet_value: 'Date' },
+    { label: 'Date', value: date },
     { label: 'Description', value: description },
-    { label: 'Division', value: admin_set, facet_value: 'admin_set' },
-    { label: 'Keyword', value: keyword, facet_value: 'Keyword' },
+    { label: 'Division', value: admin_set, facet_value: 'LibraryUnit' },
+    { label: 'Keyword', value: keyword },
     { label: 'Language', value: language, facet_value: 'Language' },
     { label: 'Location', value: location, facet_value: 'Location' },
     { label: 'Provenance', value: provenance },
     { label: 'Publisher', value: publisher, facet_value: 'Publisher' },
-    { label: 'Related Url', value: related_url, facet_value: 'related_url' },
+    { label: 'Related Url', value: related_url },
+    { label: 'Rights Holder', value: rights_holder },
+    { label: 'Source', value: source },
+    { label: 'Subject', value: subject, facet_value: 'Subject' },
     {
-      label: 'Rights Holder',
-      value: rights_holder,
-      facet_value: 'rights_holder'
+      label: 'Rights Statement',
+      value: rights_statement_text,
+      facet_value: 'RightsStatement'
     },
-    { label: 'Source', value: source, facet_value: 'source' },
-    { label: 'Subject', value: subject, facet_value: 'subject' },
-    { label: 'Rights Statement', value: rights_statement_text },
-    { label: 'Genre', value: genre, facet_value: 'genre' },
-    {
-      label: 'Physical Description material',
-      value: material,
-      facet_value: 'physical_description'
-    },
-    {
-      label: 'Physical Description size',
-      value: size,
-      facet_value: 'physical_description'
-    },
-    { label: 'Style Period', value: style_period, facet_value: 'style_period' },
-    { label: 'Technique', value: technique, facet_value: 'technique' }
+    { label: 'Genre', value: genre, facet_value: 'Genre' },
+    { label: 'Physical Description material', value: material },
+    { label: 'Physical Description size', value: size },
+    { label: 'Style Period', value: style_period, facet_value: 'StylePeriod' },
+    { label: 'Technique', value: technique, facet_value: 'Technique' }
   ];
 
   const findThisItemPanel = [

--- a/src/components/ItemDetail/MetadataDisplay.js
+++ b/src/components/ItemDetail/MetadataDisplay.js
@@ -2,35 +2,41 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MetadataDisplay = props => {
-  const { title, items } = props;
+  const { title, items, facet_value = '' } = props;
+
+  let itemText = item => {
+    return item.label ? item.label : item;
+  };
 
   let multipleItems = item => {
-    if (item.label) {
-      return <li key={item.label}>{item.label}</li>;
+    let text = itemText(item);
+    if (facet_value) {
+      return (
+        <li key={text}>
+          <a href={`/reactivesearch?${facet_value}=["${text}"]`}>{text}</a>
+        </li>
+      );
     } else {
-      return <li key={item}>{item}</li>;
+      return <li key={text}>{text}</li>;
     }
   };
 
   let singleItem = item => {
-    if (item.label) {
-      return <p key={item.label}>{item.label}</p>;
+    let text = itemText(item);
+    if (facet_value) {
+      return (
+        <p key={text}>
+          <a href={`/reactivesearch?${facet_value}=["${text}"]`}>{text}</a>
+        </p>
+      );
     } else {
-      return <p key={item}>{item}</p>;
+      return <p key={text}>{text}</p>;
     }
   };
 
   let display;
 
-  if (title === 'Contributor') {
-    display = items.map(item => (
-      <li key={item.label}>
-        <a href={`/reactivesearch?Contributor=["${item.label}"]`}>
-          {item.label}
-        </a>
-      </li>
-    ));
-  } else if (typeof items === 'string') display = singleItem(items);
+  if (typeof items === 'string') display = singleItem(items);
   else if (Array.isArray(items))
     display = items.map(item => multipleItems(item));
 

--- a/src/components/ItemDetail/TabContent.js
+++ b/src/components/ItemDetail/TabContent.js
@@ -14,6 +14,7 @@ const TabContent = props => {
           key={item.label}
           title={item.label}
           items={item.value}
+          facet_value={item.facet_value}
         />
       ))}
     </div>


### PR DESCRIPTION
fixes #56 

The existence of a `facet_value` key is what tells the `MetadataDisplay` component to makes the metadata term linkable to search results, as well as the value of the search term. It gives us a bit of flexibility since values like `Division` is only the display value, but in elasticsearch and in donut it's referred to as `admin_set`