### PR TITLE
Update Layout file to render only once depending on authToken status

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -19,15 +19,8 @@ export function forceLogout() {
 }
 
 export const fetchApiToken = () => {
-  const cookie = document.cookie;
-
-  return dispatch => {
-    const request = async () => {
-      let response = await nulApi.extractApiToken(cookie);
-
-      // Dispatch success action
-      dispatch(fetchApiTokenSuccess(response));
-    };
-    request();
+  return async dispatch => {
+    let response = await nulApi.extractApiToken(document.cookie);
+    dispatch(fetchApiTokenSuccess(response));
   };
 };

--- a/src/containers/Layout.js
+++ b/src/containers/Layout.js
@@ -29,7 +29,14 @@ export class Layout extends Component {
   }
 
   render() {
-    const apiToken = this.props.authToken || '';
+    const apiToken = this.props.authToken;
+
+    // Delay rendering of component until the authToken has processed
+    // This avoids 'double' rendering of the entire app's components
+    // TODO: Look into an alternate way to wrap ReactiveBase around only the components which need it?
+    if (typeof apiToken === 'undefined') {
+      return null;
+    }
 
     return (
       <ReactiveBase


### PR DESCRIPTION
Get's rid of the double rendering, and memory leak.