### PR TITLE
Fix multiple titles and alternate titles display on Item Detail page

### DIFF
--- a/src/components/ItemDetail/ItemDetail.js
+++ b/src/components/ItemDetail/ItemDetail.js
@@ -8,8 +8,8 @@ const ItemDetail = props => {
   }
 
   const {
-    title: { primary: [title] } = '',
-    title: { alternate: [alternate] } = '',
+    title: { primary: title } = '',
+    title: { alternate: alternateTitle } = '',
     abstract: [abstract] = '',
     caption: [caption] = '',
     collection = null,
@@ -50,7 +50,7 @@ const ItemDetail = props => {
 
   const metadataPanel = [
     { label: 'Title', value: title },
-    { label: 'Alternate Title', value: alternate },
+    { label: 'Alternate Title', value: alternateTitle },
     { label: 'Abstract', value: abstract },
     { label: 'Caption', value: caption },
     { label: 'Creator', value: creator, facet_value: 'Creator' },

--- a/src/services/elasticsearch-parser.js
+++ b/src/services/elasticsearch-parser.js
@@ -76,11 +76,15 @@ export function getESTitle(_source) {
     return '';
   }
   const { title } = _source;
-  let primary = title.primary.length > 0 ? title.primary[0] : '';
-  let alternate =
-    title.alternate && title.alternate.length > 0 ? title.alternate : '';
 
-  return `${primary} ${alternate ? ` (${alternate})` : ''}`;
+  // Single title
+  if (title.primary.length === 0) {
+    return title.primary.length;
+  }
+  // Multiple titles, delimit with a comma
+  return title.primary.map((title, i) => {
+    return i > 0 ? `, ${title}` : title;
+  });
 }
 
 function getIIIFUrlKey(modelType) {


### PR DESCRIPTION
This fixes the title display.  Upon inspection of the Item Detail pages' components, it's pretty over-engineered.  Chris S went crazy on it, ha.  I'll clean that up in the future.

