### PR TITLE
Consolidate reactive search multilists into a wrapper component

### DIFF
--- a/src/components/Collection/SidebarFilterTab.js
+++ b/src/components/Collection/SidebarFilterTab.js
@@ -2,25 +2,18 @@ import React from 'react';
 import Collapsible from 'react-collapsible';
 import CollapsibleHeader from '../CollapsibleHeader';
 import YearSlider from '../reactive-search-wrappers/YearSlider';
-import { MultiList } from '@appbaseio/reactivesearch';
 import {
   COLLECTION_ITEMS_SEARCH_BAR_COMPONENT_ID,
   imageFacets,
   imageFilters
 } from '../../services/reactive-search';
+import RSMultiList from '../reactive-search-wrappers/RSMultiList';
 
 const SidebarFilterTab = props => {
   const allFilters = [
     COLLECTION_ITEMS_SEARCH_BAR_COMPONENT_ID,
     ...imageFilters
   ];
-
-  // Css class name helper
-  const multiListInnerClass = {
-    title: 'rs-facet-title',
-    list: 'rs-facet-list',
-    label: 'rs-facet-label'
-  };
 
   return (
     <div className="collapsible-no-side-margins">
@@ -32,22 +25,7 @@ const SidebarFilterTab = props => {
               open={true}
               key={facet.name}
             >
-              <MultiList
-                key={facet.name}
-                innerClass={multiListInnerClass}
-                componentId={facet.name.replace(/\s+/g, '')}
-                dataField={facet.field}
-                title=""
-                showCheckbox={false}
-                showMissing={true}
-                showSearch={false}
-                URLParams={true}
-                react={{
-                  and: allFilters.filter(entry => {
-                    return entry !== facet.name.replace(/\s+/g, '');
-                  })
-                }}
-              />
+              <RSMultiList facet={facet} title="" allFilters={allFilters} />
             </Collapsible>
           );
         })}

--- a/src/components/reactive-search-wrappers/RSMultiList.js
+++ b/src/components/reactive-search-wrappers/RSMultiList.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { MultiList } from '@appbaseio/reactivesearch';
+import PropTypes from 'prop-types';
+
+// Css class name helper
+const multiListInnerClass = {
+  title: 'rs-facet-title',
+  list: 'rs-facet-list',
+  label: 'rs-facet-label'
+};
+
+const RSMultiList = props => {
+  const { allFilters, defaultVal, facet, title } = props;
+
+  return (
+    <MultiList
+      componentId={facet.name.replace(/\s+/g, '')}
+      dataField={facet.field}
+      defaultSelected={defaultVal}
+      innerClass={multiListInnerClass}
+      missingLabel="None"
+      react={{
+        and: allFilters.filter(entry => {
+          return entry !== facet.name.replace(/\s+/g, '');
+        })
+      }}
+      showCheckbox={false}
+      showMissing={true}
+      showSearch={false}
+      title={title}
+      URLParams={true}
+    />
+  );
+};
+
+RSMultiList.propTypes = {
+  allFilters: PropTypes.array,
+  defaultVal: PropTypes.array,
+  facet: PropTypes.object,
+  title: PropTypes.string
+};
+
+export default RSMultiList;

--- a/src/components/reactive-search-wrappers/RSMultiList.js
+++ b/src/components/reactive-search-wrappers/RSMultiList.js
@@ -10,7 +10,7 @@ const multiListInnerClass = {
 };
 
 const RSMultiList = props => {
-  const { allFilters, defaultVal, facet, title } = props;
+  const { allFilters, defaultVal = [], facet, title } = props;
 
   return (
     <MultiList

--- a/src/components/reactive-search-wrappers/YearSlider.js
+++ b/src/components/reactive-search-wrappers/YearSlider.js
@@ -3,7 +3,7 @@ import { DynamicRangeSlider } from '@appbaseio/reactivesearch';
 import PropTypes from 'prop-types';
 
 const YearSlider = props => {
-  const title = typeof props.title === undefined ? 'Date' : '';
+  const title = typeof props.title === 'undefined' ? 'Date' : props.title;
 
   return (
     <DynamicRangeSlider

--- a/src/containers/CollectionContainer.js
+++ b/src/containers/CollectionContainer.js
@@ -126,6 +126,7 @@ export class CollectionContainer extends Component {
                     }}
                     queryFormat="or"
                     placeholder="Search within collection"
+                    showFilter={true}
                     URLParams={false}
                   />
                   <SelectedFilters />

--- a/src/containers/GlobalSearchContainer.js
+++ b/src/containers/GlobalSearchContainer.js
@@ -27,9 +27,8 @@ class GlobalSearchContainer extends Component {
   };
 
   handleClick = e => {
-    const queryString = `?search="${this.textInput.value.replace(' ', '+')}"`;
     this.props.searchToggle();
-    this.props.history.push(`/search${queryString}`);
+    this.props.history.push(`/search`);
   };
 
   handleKeyPress = e => {
@@ -85,7 +84,7 @@ class GlobalSearchContainer extends Component {
                 queryFormat="or"
                 placeholder="Search for an item"
                 showFilter={false}
-                URLParams={true}
+                URLParams={false}
               />
             </div>
           </div>

--- a/src/containers/ReactivesearchContainer.js
+++ b/src/containers/ReactivesearchContainer.js
@@ -27,6 +27,10 @@ class ReactivesearchContainer extends Component {
     this.facetValue = null;
   }
 
+  state = {
+    componentLoaded: false
+  };
+
   componentDidMount() {
     this.searchValue = this.props.location.state
       ? this.props.location.state.searchValue
@@ -34,6 +38,8 @@ class ReactivesearchContainer extends Component {
     this.facetValue = this.props.location.state
       ? this.props.location.state.facetValue
       : '';
+
+    this.setState({ componentLoaded: true });
   }
 
   /**
@@ -54,6 +60,7 @@ class ReactivesearchContainer extends Component {
 
   render() {
     const allFilters = [GLOBAL_SEARCH_BAR_COMPONENT_ID, ...imageFilters];
+    const { componentLoaded } = this.state;
 
     //TODO: Break this into components
     return (
@@ -61,22 +68,23 @@ class ReactivesearchContainer extends Component {
         <div id="page" className="search">
           <div id="sidebar" className="left-sidebar content" tabIndex="-1">
             <div className="box">
-              {imageFacets.map(facet => {
-                let defaultVal =
-                  this.facetValue && this.facetValue === facet.name
-                    ? [this.searchValue]
-                    : [];
+              {componentLoaded &&
+                imageFacets.map(facet => {
+                  let defaultVal =
+                    this.facetValue && this.facetValue === facet.name
+                      ? [this.searchValue]
+                      : [];
 
-                return (
-                  <RSMultiList
-                    key={facet.name}
-                    allFilters={allFilters}
-                    defaultVal={defaultVal}
-                    facet={facet}
-                    title={facet.name}
-                  />
-                );
-              })}
+                  return (
+                    <RSMultiList
+                      key={facet.name}
+                      allFilters={allFilters}
+                      defaultVal={defaultVal}
+                      facet={facet}
+                      title={facet.name}
+                    />
+                  );
+                })}
               <YearSlider title="Date" />
             </div>
           </div>

--- a/src/containers/ReactivesearchContainer.js
+++ b/src/containers/ReactivesearchContainer.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import {
   DataSearch,
-  MultiList,
   SelectedFilters,
   ReactiveList
 } from '@appbaseio/reactivesearch';
@@ -19,6 +18,7 @@ import {
   imageFacets,
   imageFilters
 } from '../services/reactive-search';
+import RSMultiList from '../components/reactive-search-wrappers/RSMultiList';
 
 class ReactivesearchContainer extends Component {
   constructor(props) {
@@ -55,13 +55,6 @@ class ReactivesearchContainer extends Component {
   render() {
     const allFilters = [GLOBAL_SEARCH_BAR_COMPONENT_ID, ...imageFilters];
 
-    // Css class name helper
-    const multiListInnerClass = {
-      title: 'rs-facet-title',
-      list: 'rs-facet-list',
-      label: 'rs-facet-label'
-    };
-
     //TODO: Break this into components
     return (
       <div className="standard-page">
@@ -73,28 +66,18 @@ class ReactivesearchContainer extends Component {
                   this.facetValue && this.facetValue === facet.name
                     ? [this.searchValue]
                     : [];
+
                 return (
-                  <MultiList
+                  <RSMultiList
                     key={facet.name}
-                    className={'adam'}
-                    innerClass={multiListInnerClass}
-                    componentId={facet.name.replace(/\s+/g, '')}
-                    dataField={facet.field}
-                    defaultSelected={defaultVal}
+                    allFilters={allFilters}
+                    defaultVal={defaultVal}
+                    facet={facet}
                     title={facet.name}
-                    showCheckbox={false}
-                    showMissing={true}
-                    showSearch={false}
-                    URLParams={true}
-                    react={{
-                      and: allFilters.filter(entry => {
-                        return entry !== facet.name.replace(/\s+/g, '');
-                      })
-                    }}
                   />
                 );
               })}
-              <YearSlider />
+              <YearSlider title="Date" />
             </div>
           </div>
           <main id="main-content" className="content" tabIndex="-1">

--- a/src/styles/sass/nulib-collections/_reactive-search.scss
+++ b/src/styles/sass/nulib-collections/_reactive-search.scss
@@ -5,6 +5,8 @@
 
 .rs-facet-list {
   margin: 1em 0 !important;
+  overflow-x: none;
+  overflow-y: auto;
 
   li {
     height: auto !important;


### PR DESCRIPTION
Fixes #132 

Reactive Search provides a way to limit the amount of faceted values, and a default "More" button, however for some reason it's not working.  The docs say this feature is still in transition yet, so will re-evaluate in the future and see if it's stable and/or working.

For now, we're containing overflow horizontally, and letting vertical scrolling happen naturally.

This PR also creates a wrapper component to consolidate the common `MultiList` props.