### PR TITLE
Add auth token to all ElasticSearch API requests

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -27,8 +27,12 @@ function authHeader(headers = {}) {
   if (state.auth.token) {
     result['Authorization'] = 'Bearer ' + state.auth.token;
   }
-  return Object.assign(headers, result);
+  return { ...headers, ...result };
 }
+
+store.subscribe(() => {
+  getObjBase.headers = authHeader();
+});
 
 export async function getAdminSetItems(id, numResults = PAGE_SIZE) {
   const response = await client.search({


### PR DESCRIPTION
`getObjBase` needs to be refreshed with the new auth header when the state changes.