### PR TITLE
Clear applied facets to Search page when clicking on Browse Items nav…

### DIFF
--- a/src/containers/NavContainer.js
+++ b/src/containers/NavContainer.js
@@ -4,6 +4,11 @@ import { connect } from 'react-redux';
 import { searchToggle } from '../actions/search';
 import { getAllCollections } from '../api/elasticsearch-api';
 import NavCollectionsList from '../components/Nav/NavCollectionsList';
+import { withRouter } from 'react-router';
+
+// From reactivesearch - we need to hook into their Redux store to get access to the clearValues() action
+import { connect as reactiveSearchConnect } from '@appbaseio/reactivesearch/lib/utils';
+import { clearValues } from '@appbaseio/reactivecore/lib/actions';
 
 const styles = {
   searchButton: {
@@ -30,6 +35,14 @@ class NavContainer extends Component {
       });
     }
   }
+
+  handleBrowseItemsClick = e => {
+    // Currently on the Search Results page
+    if (this.props.history.location.pathname === '/search') {
+      // Clear existing filters on Search Results page
+      this.props.clearValues();
+    }
+  };
 
   handleSearchIconClick = e => {
     // Send redux action that Global Search is open or close
@@ -60,7 +73,9 @@ class NavContainer extends Component {
               </ul>
             </li>
             <li>
-              <Link to="/search">Browse Items</Link>
+              <Link to="/search" onClick={this.handleBrowseItemsClick}>
+                Browse Items
+              </Link>
             </li>
             <li id="library-search-button">
               <a
@@ -82,7 +97,17 @@ const mapDispatchToProps = dispatch => ({
   searchToggle: () => dispatch(searchToggle())
 });
 
+const mapRSDispatchToProps = dispatch => ({
+  clearValues: () => dispatch(clearValues())
+});
+
+const NavContainerWithRouter = withRouter(NavContainer);
+const ConnectedNavContainerWithRouter = reactiveSearchConnect(
+  null,
+  mapRSDispatchToProps
+)(NavContainerWithRouter);
+
 export default connect(
   null,
   mapDispatchToProps
-)(NavContainer);
+)(ConnectedNavContainerWithRouter);


### PR DESCRIPTION
…igation link

This will clear out any applied facets when on the Search Results page, and clicking on the "Browse Items" main navigation link.  It hooks into ReactiveSearch's Redux action to clear the results, so hopefully no more odd RS side effects are created.

fixes #257 