### PR TITLE
Use query parser for ReactiveSearch queries

### DIFF
--- a/src/containers/CollectionContainer.js
+++ b/src/containers/CollectionContainer.js
@@ -145,6 +145,13 @@ export class CollectionContainer extends Component {
       : [];
     const collectionTitle = collection ? getESTitle(collection) : '';
 
+    const queryStringQuery = (value, props) => ({
+      query_string: {
+        default_field: 'full_text',
+        query: value
+      }
+    });
+
     const renderDisplay = () => {
       if (error) {
         return <ErrorSection message={error} />;
@@ -179,6 +186,7 @@ export class CollectionContainer extends Component {
                   />
 
                   <DataSearch
+                    customQuery={queryStringQuery}
                     autosuggest={false}
                     className="datasearch web-form"
                     componentId={COLLECTION_ITEMS_SEARCH_BAR_COMPONENT_ID}

--- a/src/containers/ReactivesearchContainer.js
+++ b/src/containers/ReactivesearchContainer.js
@@ -64,6 +64,13 @@ class ReactivesearchContainer extends Component {
     const allFilters = [GLOBAL_SEARCH_BAR_COMPONENT_ID, ...imageFilters];
     const { componentLoaded } = this.state;
 
+    const queryStringQuery = (value, props) => ({
+      query_string: {
+        default_field: 'full_text',
+        query: value
+      }
+    });
+
     //TODO: Break this into components
     return (
       <div className="standard-page">
@@ -97,6 +104,7 @@ class ReactivesearchContainer extends Component {
             <div>
               <h2>Search Results</h2>
               <DataSearch
+                customQuery={queryStringQuery}
                 className="datasearch web-form"
                 componentId={GLOBAL_SEARCH_BAR_COMPONENT_ID}
                 dataField={['full_text']}


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/860

* Use a custom query for the `DataSearch` component so that the query string will be parsed, instead of just tokenized with quotes ignored: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
* This will also make possible queries like: `"new york city" OR "big apple"`
