### PR TITLE
Fix empty ReactiveSearch DataSearch text query returning no results. …

### DIFF
--- a/src/containers/CollectionContainer.js
+++ b/src/containers/CollectionContainer.js
@@ -21,7 +21,8 @@ import searchIcon from '../images/library-search.svg';
 import {
   COLLECTION_ITEMS_SEARCH_BAR_COMPONENT_ID,
   COLLECTION_DATA_CONTROLLER_ID,
-  imageFilters
+  imageFilters,
+  simpleQueryStringQuery
 } from '../services/reactive-search';
 import { connect } from 'react-redux';
 import { generateTitleTag } from '../services/helpers';
@@ -145,13 +146,6 @@ export class CollectionContainer extends Component {
       : [];
     const collectionTitle = collection ? getESTitle(collection) : '';
 
-    const queryStringQuery = (value, props) => ({
-      query_string: {
-        default_field: 'full_text',
-        query: value
-      }
-    });
-
     const renderDisplay = () => {
       if (error) {
         return <ErrorSection message={error} />;
@@ -186,7 +180,7 @@ export class CollectionContainer extends Component {
                   />
 
                   <DataSearch
-                    customQuery={queryStringQuery}
+                    customQuery={simpleQueryStringQuery}
                     autosuggest={false}
                     className="datasearch web-form"
                     componentId={COLLECTION_ITEMS_SEARCH_BAR_COMPONENT_ID}

--- a/src/containers/GlobalSearchContainer.js
+++ b/src/containers/GlobalSearchContainer.js
@@ -4,7 +4,11 @@ import { withRouter } from 'react-router';
 import { DataSearch } from '@appbaseio/reactivesearch';
 import * as actions from '../actions/search';
 import { SlideDown } from 'react-slidedown';
-import { GLOBAL_SEARCH_BAR_COMPONENT_ID } from '../services/reactive-search';
+import {
+  DATASEARCH_PLACEHOLDER,
+  GLOBAL_SEARCH_BAR_COMPONENT_ID,
+  simpleQueryStringQuery
+} from '../services/reactive-search';
 import 'react-slidedown/lib/slidedown.css';
 import { getTotalItemCount } from '../api/elasticsearch-api';
 
@@ -66,11 +70,13 @@ class GlobalSearchContainer extends Component {
             </div>
             <div className="for-column">
               <span>for</span>
+
               <DataSearch
                 autosuggest={false}
                 style={styles.inputWrapper}
                 className="datasearch web-form"
                 componentId={GLOBAL_SEARCH_BAR_COMPONENT_ID}
+                customQuery={simpleQueryStringQuery}
                 dataField={['full_text']}
                 filterLabel="Search"
                 icon={
@@ -94,7 +100,7 @@ class GlobalSearchContainer extends Component {
                 onClick={this.handleClick}
                 onKeyPress={this.handleKeyPress}
                 queryFormat="or"
-                placeholder="Search for an item"
+                placeholder={DATASEARCH_PLACEHOLDER}
                 showFilter={true}
                 URLParams={false}
               />

--- a/src/containers/ItemDetailContainer.test.js
+++ b/src/containers/ItemDetailContainer.test.js
@@ -56,7 +56,6 @@ xit('fetches item data from the api and sets the item on component state', async
 
   // Get derived state after all mocked network requests
   let wrapperState = wrapper.state();
-  console.log('wrapperState', wrapperState);
 
   expect(wrapperState).toHaveProperty('error');
   expect(wrapperState).toHaveProperty('collectionItems');

--- a/src/containers/ReactivesearchContainer.js
+++ b/src/containers/ReactivesearchContainer.js
@@ -14,9 +14,11 @@ import {
 import LoadingSpinner from '../components/LoadingSpinner';
 import YearSlider from '../components/reactive-search-wrappers/YearSlider';
 import {
+  DATASEARCH_PLACEHOLDER,
   GLOBAL_SEARCH_BAR_COMPONENT_ID,
   imageFacets,
-  imageFilters
+  imageFilters,
+  simpleQueryStringQuery
 } from '../services/reactive-search';
 import RSMultiList from '../components/reactive-search-wrappers/RSMultiList';
 import { generateTitleTag } from '../services/helpers';
@@ -64,14 +66,6 @@ class ReactivesearchContainer extends Component {
     const allFilters = [GLOBAL_SEARCH_BAR_COMPONENT_ID, ...imageFilters];
     const { componentLoaded } = this.state;
 
-    const queryStringQuery = (value, props) => ({
-      query_string: {
-        default_field: 'full_text',
-        query: value
-      }
-    });
-
-    //TODO: Break this into components
     return (
       <div className="standard-page">
         <Helmet>
@@ -104,12 +98,13 @@ class ReactivesearchContainer extends Component {
             <div>
               <h2>Search Results</h2>
               <DataSearch
-                customQuery={queryStringQuery}
+                customQuery={simpleQueryStringQuery}
                 className="datasearch web-form"
                 componentId={GLOBAL_SEARCH_BAR_COMPONENT_ID}
                 dataField={['full_text']}
+                debounce={1000}
                 queryFormat="or"
-                placeholder="Search for an item"
+                placeholder={DATASEARCH_PLACEHOLDER}
                 innerClass={{
                   input: 'searchbox rs-search-input',
                   list: 'suggestionlist'

--- a/src/services/reactive-search.js
+++ b/src/services/reactive-search.js
@@ -2,6 +2,8 @@
 export const COLLECTION_ITEMS_SEARCH_BAR_COMPONENT_ID = 'collection-search';
 export const GLOBAL_SEARCH_BAR_COMPONENT_ID = 'q';
 export const COLLECTION_DATA_CONTROLLER_ID = 'collection-data-controller';
+export const DATASEARCH_PLACEHOLDER =
+  'Search by title, description, or wildcard * (ie. part*)';
 
 export const facetValues = {
   COLLECTION: 'Collection',
@@ -54,3 +56,16 @@ export const imageFilters = [
   facetValues.TECHNIQUE,
   facetValues.VISIBILITY
 ];
+
+// For now, this is the ReactiveSearch DataSearch customQuery function,
+// which is used to do phrase matching with our current ElasticSearch
+// indexing configuration
+export const simpleQueryStringQuery = value => {
+  return {
+    simple_query_string: {
+      query: `${value || '*'}`,
+      fields: ['full_text'],
+      default_operator: 'or'
+    }
+  };
+};


### PR DESCRIPTION
… Introduce wildcard helper, and push ElasticSearch Simple Query String Query as a reusable, exported function.

fixes #308 
fixes https://github.com/nulib/next-generation-repository/issues/860

@davidschober @kdid So this is a result of messing with this for a while.  What this does is:
- replaces ES's `query_string query` with `simple_query_string query`.  Both would probably work...but this does in the scenarios I'm testing.
- Phrase matching with `" "` still works.
- Handles blank text input in the `DataSearch` component, and doesn't freeze up the UI.
- Makes the `DataSearch` `customQuery` a reusable function export.
- Gives a placeholder hint to the user that they can use wildcards (*) in their search.  Note I could only get trailing `*` to work...putting them at the beginning even with the `allow_leading_wildcard` property using `query_string_query` didn't seem to work.  I'm guessing this is the primary use case?  Hopefully?

I'm curious to see this behave on staging with a larger bed of test data to search on. 