### PR TITLE
Fix view all items in Library Department button on Item Details page

### DIFF
--- a/src/components/ItemDetail/ParentCollections.js
+++ b/src/components/ItemDetail/ParentCollections.js
@@ -11,43 +11,41 @@ const ParentCollections = props => {
 
   return (
     <div>
-      {item &&
-        adminSetItems && (
-          <section className="section">
-            <SectionTop
-              sectionTitle="Library Department"
-              optionalSubhead={adminSetTitle}
-              optionalButtons={[
-                {
-                  label: 'View All Items in Library Department',
-                  url: '/search',
-                  state: {
-                    facetValue: facetValues.LIBRARY_UNIT,
-                    searchValue: adminSetTitle
-                  }
+      {item && adminSetItems && (
+        <section className="section">
+          <SectionTop
+            sectionTitle="Library Department"
+            optionalSubhead={adminSetTitle}
+            optionalButtons={[
+              {
+                label: 'View All Items in Library Department',
+                url: '/search',
+                state: {
+                  facetValue: facetValues.LIBRARY_DEPARTMENT,
+                  searchValue: adminSetTitle
                 }
-              ]}
-            />
-            <PhotoGrid items={adminSetItems} hideDescriptions={true} />
-          </section>
-        )}
+              }
+            ]}
+          />
+          <PhotoGrid items={adminSetItems} hideDescriptions={true} />
+        </section>
+      )}
 
-      {item &&
-        collectionItems.length > 0 && (
-          <section>
-            <SectionTop
-              sectionTitle="Collection"
-              optionalSubhead={item.collection[0].title[0]}
-              optionalButtons={[
-                {
-                  label: 'View All Items in Collection',
-                  url: `/collections/${collectionId}`
-                }
-              ]}
-            />
-            <PhotoGrid items={collectionItems} />
-          </section>
-        )}
+      {item && collectionItems.length > 0 && (
+        <section>
+          <SectionTop
+            sectionTitle="Collection"
+            optionalSubhead={item.collection[0].title[0]}
+            optionalButtons={[
+              {
+                label: 'View All Items in Collection',
+                url: `/collections/${collectionId}`
+              }
+            ]}
+          />
+          <PhotoGrid items={collectionItems} />
+        </section>
+      )}
 
       <ThisItem item={item} />
     </div>


### PR DESCRIPTION
fixes https://github.com/nulib/next-generation-repository/issues/870

This is a fix for the "View all Items in Library Department" button on the Item Details page.  It was using the old facet name of "Library Unit".

