### PR TITLE
Update dataLayer pushes to use pipe delimiters on a string instead of…

### DIFF
--- a/src/containers/CollectionContainer.js
+++ b/src/containers/CollectionContainer.js
@@ -29,7 +29,10 @@ import PhotoBox from '../components/PhotoBox';
 import { MOBILE_BREAKPOINT } from '../services/global-vars';
 import withSizes from 'react-sizes';
 import CollectionDescription from '../components/Collection/CollectionDescription';
-import { loadDataLayer } from '../services/google-tag-manager';
+import {
+  createPipedString,
+  loadDataLayer
+} from '../services/google-tag-manager';
 
 const allFilters = [COLLECTION_ITEMS_SEARCH_BAR_COMPONENT_ID, ...imageFilters];
 
@@ -148,10 +151,16 @@ export class CollectionContainer extends Component {
   }
 
   populateGTMDataLayer(collection) {
+    const collectionTitles = getESTitle(collection).split(',');
+    const collections =
+      collectionTitles.length > 1
+        ? createPipedString(collectionTitles)
+        : collectionTitles[0];
     const dataLayer = {
-      collections: getESTitle(collection),
+      collections,
       isLoggedIn: this.props.auth.token != null
     };
+
     loadDataLayer(dataLayer);
   }
 

--- a/src/containers/ItemDetailContainer.js
+++ b/src/containers/ItemDetailContainer.js
@@ -13,7 +13,10 @@ import LargeFeature from '../components/ItemDetail/LargeFeature';
 import OpenSeadragonContainer from './OpenSeadragonContainer';
 import { Helmet } from 'react-helmet';
 import { generateTitleTag } from '../services/helpers';
-import { loadDataLayer } from '../services/google-tag-manager';
+import {
+  createPipedString,
+  loadDataLayer
+} from '../services/google-tag-manager';
 
 export class ItemDetailContainer extends Component {
   constructor(props) {
@@ -168,14 +171,16 @@ export class ItemDetailContainer extends Component {
     const contributors = item.contributor.map(contributor => contributor.label);
 
     const dataLayer = {
-      adminset: item.admin_set.title.map(title => title).join(', '),
-      collections: item.collection.map(collection =>
-        collection.title.map(title => title).join(', ')
+      adminset: createPipedString(item.admin_set.title.map(title => title)),
+      collections: createPipedString(
+        item.collection.map(collection =>
+          collection.title.map(title => title).join(', ')
+        )
       ),
-      creatorsContributors: [...creators, ...contributors],
+      creatorsContributors: createPipedString([...creators, ...contributors]),
       isLoggedIn: this.props.auth.token != null,
       rightsStatement,
-      subjects: item.subject.map(subject => subject.label),
+      subjects: createPipedString(item.subject.map(subject => subject.label)),
       visibility: item.visibility
     };
 

--- a/src/services/google-tag-manager.js
+++ b/src/services/google-tag-manager.js
@@ -36,3 +36,18 @@ export function loadDataLayer({
  * Quick way to access a key value in DataLayer
  * > window.google_tag_manager['GTM-XXXXX'].dataLayer.get('keyNameHere')
  */
+
+/**
+ * Helper function to prepare multi values we need to parse in Google Tag Manager / UA
+ * @param {Array} arr Values to convert to a piped string
+ * @returns {String}
+ */
+export function createPipedString(arr) {
+  if (arr.length === 0) {
+    return '';
+  }
+
+  const trimmedArray = arr.map(value => value.trim());
+
+  return trimmedArray.join('|');
+}


### PR DESCRIPTION
… sending in arrays

fixes #340 

Hey all, this should be the final update which syncs up Google Tag Manager `dataLayer` stuff that David needs and wants pushed to production fairly soon.