### PR TITLE
Update Openseadragon styles for all major mobile devices and iPad

### DIFF
--- a/src/components/OpenSeadragonViewer.js
+++ b/src/components/OpenSeadragonViewer.js
@@ -3,14 +3,6 @@ import OpenSeadragon from 'openseadragon';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-const styles = {
-  viewer: {
-    display: 'inline-block',
-    width: '100%',
-    height: '700px'
-  }
-};
-
 class OpenSeadragonViewer extends Component {
   constructor(props) {
     super(props);
@@ -86,7 +78,7 @@ class OpenSeadragonViewer extends Component {
 
     return (
       <div>
-        <div id="toolbarDiv" className="toolbar" style={styles.toolbar}>
+        <div id="toolbarDiv" className="toolbar">
           <a
             id="zoom-in"
             href="#zoom-in"
@@ -132,7 +124,7 @@ class OpenSeadragonViewer extends Component {
           </a>
         </div>
 
-        <div id="openseadragon1" style={styles.viewer} />
+        <div id="openseadragon1" className="open-seadragon-container" />
       </div>
     );
   }

--- a/src/styles/sass/nulib-collections/_item-view.scss
+++ b/src/styles/sass/nulib-collections/_item-view.scss
@@ -110,6 +110,22 @@
       }
     }
   }
+
+  @media screen and (max-width: 768px) {
+    &.large-feature {
+      h3 {
+        display: none;
+      }
+
+      .large-feature-inner {
+        margin-top: 0;
+
+        .content-side h4 {
+          margin-bottom: 1rem;
+        }
+      }
+    }
+  }
 }
 
 .download-option-box {

--- a/src/styles/sass/nulib-collections/_open-seadragon.scss
+++ b/src/styles/sass/nulib-collections/_open-seadragon.scss
@@ -1,10 +1,24 @@
+.open-seadragon-container {
+  display: inline-block;
+  width: 100%;
+  height: 300px;
+
+  @media screen and (min-height: 668px) {
+    height: 400px;
+  }
+  @media screen and (min-height: 800px) {
+    height: 450px;
+  }
+}
+
 .toolbar {
+  background: $rich-black-50;
   position: absolute !important;
   right: 0px;
-  top: 40%;
-  background: $rich-black-50;
-  z-index: 100;
+  top: 50%;
   opacity: 0.8;
+  transform: translateY(-50%);
+  z-index: 100;
 }
 
 a.toolbar-controls {
@@ -15,5 +29,11 @@ a.toolbar-controls {
 
   &:hover {
     background: darken($rich-black-50, 10%);
+  }
+}
+
+@media screen and (max-width: 768px) {
+  a.toolbar-controls {
+    font-size: 1.25rem;
   }
 }


### PR DESCRIPTION
fixes #288 

This fix supports a decent Open Seadragon display for all major phones and iPad:

#### Galaxy S5
![devbox library northwestern edu_3333_items_54b9bfed-74ed-4a3b-82a2-a424fafed6f4(Galaxy S5)](https://user-images.githubusercontent.com/3020266/54687538-d56c7100-4ae9-11e9-99c9-4062457190cd.png)

#### Pixel 2
![devbox library northwestern edu_3333_items_54b9bfed-74ed-4a3b-82a2-a424fafed6f4(Pixel 2)](https://user-images.githubusercontent.com/3020266/54687549-dc937f00-4ae9-11e9-9297-f3258de0ae0d.png)

#### Pixel 2 XL
![devbox library northwestern edu_3333_items_54b9bfed-74ed-4a3b-82a2-a424fafed6f4(Pixel 2 XL)](https://user-images.githubusercontent.com/3020266/54687563-e6b57d80-4ae9-11e9-9ef3-9eecec42e1b8.png)

#### iPhone 5
![devbox library northwestern edu_3333_items_54b9bfed-74ed-4a3b-82a2-a424fafed6f4(iPhone 5_SE)](https://user-images.githubusercontent.com/3020266/54687575-f0d77c00-4ae9-11e9-9795-9bf07bb80dba.png)

#### iPhone 6/7/8
![devbox library northwestern edu_3333_items_54b9bfed-74ed-4a3b-82a2-a424fafed6f4(iPhone 6_7_8)](https://user-images.githubusercontent.com/3020266/54687586-f765f380-4ae9-11e9-9032-ca3649222971.png)

#### iPhone 6/7/8 Plus
![devbox library northwestern edu_3333_items_54b9bfed-74ed-4a3b-82a2-a424fafed6f4(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/3020266/54687596-ff259800-4ae9-11e9-8212-9484b4d9eb0c.png)

#### iPhone X
![devbox library northwestern edu_3333_items_54b9bfed-74ed-4a3b-82a2-a424fafed6f4(iPhone X)](https://user-images.githubusercontent.com/3020266/54687613-06e53c80-4aea-11e9-8a02-5644a3933ed3.png)

#### iPad
![devbox library northwestern edu_3333_items_54b9bfed-74ed-4a3b-82a2-a424fafed6f4(iPad)](https://user-images.githubusercontent.com/3020266/54687627-0f3d7780-4aea-11e9-85eb-04c8e0896c05.png)
