### PR TITLE
Fix mobile navigation display of lines breaking in weird spots, and a…

### DIFF
--- a/src/components/Collection/CollectionDescription.js
+++ b/src/components/Collection/CollectionDescription.js
@@ -29,19 +29,17 @@ class CollectionDescription extends Component {
 
     return (
       <React.Fragment>
-        <p>
-          {tooLong && !expanded && description[0]}
-          {(!tooLong || expanded) && description}
-          {tooLong && (
-            <a href="/" onClick={this.handleClick}>
-              <FontAwesomeIcon
-                icon={expanded ? 'angle-up' : 'angle-right'}
-                style={styles.moreLess}
-              />
-              {expanded ? 'Less' : 'More'}
-            </a>
-          )}
-        </p>
+        {tooLong && !expanded && description[0]}
+        {(!tooLong || expanded) && description}
+        {tooLong && (
+          <a href="/" onClick={this.handleClick}>
+            <FontAwesomeIcon
+              icon={expanded ? 'angle-up' : 'angle-right'}
+              style={styles.moreLess}
+            />
+            {expanded ? 'Less' : 'More'}
+          </a>
+        )}
       </React.Fragment>
     );
   }

--- a/src/components/Header/MobileLinks.js
+++ b/src/components/Header/MobileLinks.js
@@ -20,8 +20,6 @@ class MobileLinks extends Component {
   };
 
   handleMenuClick = e => {
-    e.preventDefault();
-
     this.setState({
       navOpen: !this.state.navOpen,
       searchOpen: false
@@ -68,13 +66,9 @@ class MobileLinks extends Component {
 
     return (
       <div id="mobile-links">
-        <a
-          href="#mobile-nav"
-          className={classes}
-          onClick={this.handleMenuClick}
-        >
+        <button className={classes} onClick={this.handleMenuClick}>
           <span className="hide-label">Menu</span>
-        </a>
+        </button>
         <MobileNav
           {...this.props}
           collections={collections}
@@ -82,15 +76,14 @@ class MobileLinks extends Component {
           closeMenu={this.handleMenuClick}
         />
 
-        <a
-          href="#mobile-search"
+        <button
           className={`mobile-link mobile-search-link ${
             searchOpen ? 'open' : ''
           }`}
           onClick={this.handleSearchClick}
         >
           <span className="hide-label">Search</span>
-        </a>
+        </button>
 
         {this.state.searchOpen && (
           <div id="mobile-search">

--- a/src/components/Header/MobileNav.js
+++ b/src/components/Header/MobileNav.js
@@ -84,11 +84,8 @@ class MobileNav extends Component {
         <div id="mobile-nav-bottom">
           {/* from #global-links */}
           <ul id="mobile-nav-bottom-left">
-            <GlobalLinks />
-          </ul>
-          {/* from #quick-links */}
-          <ul id="mobile-nav-bottom-right">
             <QuickLinksItems quickLinks={this.props.quickLinks} />
+            <GlobalLinks />
           </ul>
         </div>
       </nav>

--- a/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
+++ b/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
@@ -26,6 +26,9 @@
 
 @media screen and (max-width: 768px) {
   .mobile-link {
+    // Because we're using a <button> instead of <a>, for accessibility
+    padding: 0;
+
     &.mobile-nav-link {
       background: url('images/hamburger-purple.svg') no-repeat center/20px 20px;
     }
@@ -36,6 +39,13 @@
         background: #401f68 url('images/alert-x-white-home.svg') no-repeat
           center/20px 20px;
       }
+    }
+  }
+
+  #mobile-nav-bottom {
+    #mobile-nav-bottom-left {
+      width: 100%;
+      display: block;
     }
   }
 }


### PR DESCRIPTION
…lso some click handling which was preventing the Sign In link from firing the first time clicked.

Screen shot of updated mobile navigation layout (bottom links changed).

![devbox library northwestern edu_3333_about(iPhone 6_7_8)](https://user-images.githubusercontent.com/3020266/54704253-5e92a080-4b08-11e9-9720-57848387f756.png)
