### PR TITLE
Query params appended to the Link url when going from Item Details pa…

### DIFF
--- a/src/components/ItemDetail/MetadataDisplay.js
+++ b/src/components/ItemDetail/MetadataDisplay.js
@@ -14,19 +14,13 @@ const MetadataDisplay = props => {
   };
 
   let linkElement = (facetValue, searchValue) => {
-    return (
-      <Link
-        to={{
-          pathname: '/search',
-          state: {
-            facetValue: facetValue,
-            searchValue: searchValue
-          }
-        }}
-      >
-        {searchValue}
-      </Link>
+    // TODO: create a map object for 'facetValue' in globals, so it's not just assumed that it's camelCased
+    const adjustedFacetValue = facetValue.split(' ').join('');
+    const adjustedSearchValue = searchValue.split(' ').join('+');
+    const encoded = encodeURI(
+      `${adjustedFacetValue}=["${adjustedSearchValue}"]`
     );
+    return <Link to={`/search?${encoded}`}>{searchValue}</Link>;
   };
 
   let multipleItems = item => {

--- a/src/containers/Layout.js
+++ b/src/containers/Layout.js
@@ -69,7 +69,7 @@ export class Layout extends Component {
             path={ROUTES.ITEM_DETAIL.path}
             component={ItemDetailContainer}
           />
-          <Route path={ROUTES.SEARCH.path}>
+          <Route exact path={ROUTES.SEARCH.path}>
             <ReactiveBaseWrapper apiToken={apiToken}>
               <ReactivesearchContainer />
             </ReactiveBaseWrapper>

--- a/src/containers/ReactivesearchContainer.js
+++ b/src/containers/ReactivesearchContainer.js
@@ -32,12 +32,6 @@ const breadcrumbs = [
 ];
 
 class ReactivesearchContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.searchValue = null;
-    this.facetValue = null;
-  }
-
   state = {
     componentLoaded: false,
     showSidebar: false
@@ -45,14 +39,6 @@ class ReactivesearchContainer extends Component {
 
   componentDidMount() {
     loadDataLayer({ pageTitle: ROUTES.SEARCH.title });
-
-    this.searchValue = this.props.location.state
-      ? this.props.location.state.searchValue
-      : '';
-    this.facetValue = this.props.location.state
-      ? this.props.location.state.facetValue
-      : '';
-
     this.setState({ componentLoaded: true });
   }
 
@@ -83,11 +69,6 @@ class ReactivesearchContainer extends Component {
       ...imageFilters
     ];
     const { componentLoaded, showSidebar } = this.state;
-    const { location } = this.props;
-    const globalSearchValue =
-      location.state && location.state.globalSearch
-        ? location.state.globalSearch
-        : null;
 
     return (
       <div className="standard-page">
@@ -138,7 +119,6 @@ class ReactivesearchContainer extends Component {
                 'all_subjects'
               ]}
               debounce={1000}
-              defaultSelected={globalSearchValue || null}
               filterLabel="Search"
               innerClass={{
                 input: 'searchbox rs-search-input',
@@ -173,6 +153,7 @@ class ReactivesearchContainer extends Component {
               }}
               sortBy="asc"
               size={12}
+              URLParams={true}
             />
           </main>
         </div>


### PR DESCRIPTION
…ge to Search page, instead of using Route state

This is a partial fix for https://github.com/nulib/next-generation-repository/issues/888. It fixes the initial issue of not being able to go 'back' to the Item Details page on first click of back button on Search page.

However this does introduce another bug, which occurs when you deselect the same facet (in the Search page, facets bar) that was clicked on in the Item Details page.   In this scenario you'd have to click back about 100 times to finally get back.  Not sure what `ReactiveSearch` is doing under the hood with connecting URL params to the browser `history` stack, but I'm going to create a new ticket to upgrade to `ReactiveSearch` 3.x and see if any of this buggy behavior got worked out.