### PR TITLE
Account for multivalues in preparing Google Structured data for Item Details page

### DIFF
--- a/src/services/google-structured-data.js
+++ b/src/services/google-structured-data.js
@@ -57,12 +57,9 @@ export function loadItemStructuredData(item, pathname) {
     thumbnail: item.thumbnail_url,
     url: `${productionUrl}${pathname}`,
     ...(item.subject && {
-      about: item.subject
-        // If there is a comma in the value, wrap value in double quotes
-        .map(x => accountForCommas(x.label))
-        .join(', ')
+      about: item.subject.map(x => x.label)
     }),
-    ...(item.creator.length > 0 && { author: item.creator[0].label }),
+    ...(item.creator.length > 0 && { author: item.creator.map(x => x.label) }),
     ...(item.subject && {
       contentLocation: item.subject
         .filter(x => x.role === 'geographical')
@@ -79,7 +76,7 @@ export function loadItemStructuredData(item, pathname) {
     ...(item.modified_date && { dateModified: item.modified_date }),
     ...(item.description && { description: item.description.join(' ') }),
     ...(item.genre && {
-      genre: item.genre.map(x => accountForCommas(x.label)).join(', ')
+      genre: item.genre.map(x => x.label)
     }),
 
     ...(item.keyword && {

--- a/src/services/google-structured-data.test.js
+++ b/src/services/google-structured-data.test.js
@@ -41,7 +41,7 @@ describe('collection structured data', () => {
 describe('work structured data', () => {
   let anotherMock = {
     creator: [{ label: 'john' }],
-    contributor: [{ label: 'bob' }],
+    contributor: [{ label: 'bob' }, { label: 'Rush, Otis' }],
     iiif_manifest:
       'https://iiif.stack.rdc.library.northwestern.edu/public/c7/86/33/6b',
     representative_file_url: 'http://location.com/xyz',
@@ -64,11 +64,11 @@ describe('work structured data', () => {
 
   it('returns a quoted value when a comma is present in a metadata value', () => {
     const obj = gsd.loadItemStructuredData(anotherMock, pathName);
-    expect(obj.about).toContain('"Smith, John"');
+    expect(obj.contributor).toContain('"Rush, Otis"');
 
-    anotherMock.subject = [{ label: 'Smith John' }, { label: 'Ben' }];
+    anotherMock.contributor = [{ label: 'Smith John' }, { label: 'Ben' }];
     const obj2 = gsd.loadItemStructuredData(anotherMock, pathName);
-    expect(obj2.about).toContain('Smith John');
-    expect(obj2.about).not.toContain('"Smith, John"');
+    expect(obj2.contributor).toContain('Smith John');
+    expect(obj2.contributor).not.toContain('"Smith, John"');
   });
 });


### PR DESCRIPTION
…Details page

Updates certain structured data "multi value" fields to be of type `array` instead of a comma delimited string.   See https://github.com/nulib/next-generation-repository/issues/162 for more info