### PR TITLE
Update Catalog Key metadata label to NUsearch

### DIFF
--- a/src/components/ItemDetail/ItemDetail.js
+++ b/src/components/ItemDetail/ItemDetail.js
@@ -118,7 +118,7 @@ const ItemDetail = props => {
     { label: 'Box Number', value: boxNumber },
     { label: 'Call Number', value: callNumber },
     {
-      label: 'Catalog Key',
+      label: 'NUsearch',
       value: catalogKey,
       external_url: getPrimoLink(catalogKey)
     },

--- a/src/components/ItemDetail/MetadataDisplay.js
+++ b/src/components/ItemDetail/MetadataDisplay.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Mailto from 'react-protected-mailto';
 
 // Array of metadata items which are urls and should link externally
-const externalUrlLabels = ['Related Url', 'Catalog Key'];
+const externalUrlLabels = ['Related Url', 'NUsearch'];
 
 const MetadataDisplay = props => {
   const { title, items, facet_value = '', external_url = '' } = props;


### PR DESCRIPTION
now looks like:

![image](https://user-images.githubusercontent.com/3020266/58706954-55953980-83ab-11e9-8f49-668e2a60e573.png)
