### PR TITLE
exclude child works form collections search

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -190,3 +190,30 @@ export async function getTotalItemCount() {
     return Promise.resolve(0);
   }
 }
+
+export async function getMemberIdsForImages(id) {
+  try {
+    const response = await search({
+      ...getObjBase,
+      body: {
+        query: [
+          { match: { 'model.name': 'Image' } },
+          { match: { 'collection.id': id } }
+        ],
+        size: 0,
+        aggs: {
+          members: {
+            terms: { field: 'member_ids.keyword', size: 10000 }
+          }
+        }
+      }
+    });
+    const members = response.aggregations.members.buckets.map(
+      member => member.key
+    );
+
+    return members;
+  } catch (e) {
+    return Promise.resolve(0);
+  }
+}

--- a/src/components/FacetsSidebar.js
+++ b/src/components/FacetsSidebar.js
@@ -16,7 +16,8 @@ class FacetsSidebar extends Component {
     location: PropTypes.object, // provided by { withRouter }
     match: PropTypes.object, // provided by { withRouter }
     searchValue: PropTypes.string,
-    showSidebar: PropTypes.bool
+    showSidebar: PropTypes.bool,
+    excludes: PropTypes.array
   };
 
   isSearchPage = () => {
@@ -24,7 +25,10 @@ class FacetsSidebar extends Component {
   };
 
   collectionsQuery = () => {
-    return collectionDefaultQuery(this.props.match.params.id);
+    return collectionDefaultQuery(
+      this.props.match.params.id,
+      this.props.excludes
+    );
   };
 
   render() {

--- a/src/containers/CollectionContainer.js
+++ b/src/containers/CollectionContainer.js
@@ -48,7 +48,8 @@ export class CollectionContainer extends Component {
     items: null,
     loading: true,
     showSidebar: false,
-    structuredData: null
+    structuredData: null,
+    excludes: null
   };
 
   componentDidMount() {
@@ -79,8 +80,8 @@ export class CollectionContainer extends Component {
   }
 
   defaultQuery = () => {
-    const { collection } = this.state;
-    return collection ? collectionDefaultQuery(collection.id) : null;
+    const { collection, excludes } = this.state;
+    return collection ? collectionDefaultQuery(collection.id, excludes) : null;
   };
 
   getApiData(id) {
@@ -95,6 +96,8 @@ export class CollectionContainer extends Component {
     const request = async () => {
       const response = await elasticsearchApi.getCollection(id);
       let error = null;
+
+      const member_ids = await elasticsearchApi.getMemberIdsForImages(id);
 
       // Handle errors
       // Generic error
@@ -121,6 +124,7 @@ export class CollectionContainer extends Component {
 
       this.setState({
         collection: response._source,
+        excludes: member_ids,
         error,
         loading: false,
         structuredData: loadCollectionStructuredData(
@@ -185,7 +189,8 @@ export class CollectionContainer extends Component {
       error,
       loading,
       showSidebar,
-      structuredData
+      structuredData,
+      excludes
     } = this.state;
     const { isMobile } = this.props;
     const breadCrumbData = collection
@@ -219,13 +224,14 @@ export class CollectionContainer extends Component {
         return null;
       }
 
-      if (collection) {
+      if (collection && excludes) {
         return (
           <div>
             <FacetsSidebar
               facets={imageFacetsNoCollection}
               filters={allFilters}
               showSidebar={showSidebar}
+              excludes={excludes}
             />
             <main
               id="main-content"

--- a/src/services/reactive-search.js
+++ b/src/services/reactive-search.js
@@ -84,11 +84,18 @@ export const imagesOnlyDefaultQuery = () => {
   };
 };
 
-export const collectionDefaultQuery = collectionId => {
+export const collectionDefaultQuery = (collectionId, excludes = []) => {
   return {
     query: {
-      match: {
-        'collection.id': collectionId
+      bool: {
+        must: {
+          match: { 'collection.id': collectionId }
+        },
+        must_not: {
+          terms: {
+            _id: excludes
+          }
+        }
       }
     }
   };


### PR DESCRIPTION
To suppress child works from results we need to show only works that have no parents.

Parent/Child work is stored in Elasticsearch field `member_ids` on the **parent** work (this array also contains file_sets)

This approach seems to work.... not sure if this will scale - there might be a better way to do this query...

I tested with my local Glaze environment pointed at staging and it didn't break or seem noticably slow. (Can't point at production just yet as the index doesn't have `member_ids` yet.)