### PR TITLE
Only return NUL Collections in Collections queries

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -71,7 +71,14 @@ export async function getAllCollections(numResults = PAGE_SIZE) {
     body: {
       size: numResults,
       query: {
-        match: { 'model.name': 'Collection' }
+        bool: {
+          must: [
+            { match: { 'model.name': 'Collection' } },
+            {
+              match: { 'collection_type_idd.title.keyword': 'NUL Collection' }
+            }
+          ]
+        }
       },
       sort: [
         {
@@ -105,6 +112,9 @@ export async function getCollectionsByKeyword(keyword, numResults = PAGE_SIZE) {
         bool: {
           must: [
             { match: { 'model.name': 'Collection' } },
+            {
+              match: { 'collection_type_idd.title.keyword': 'NUL Collection' }
+            },
             { match: { keyword: keyword } }
           ]
         }


### PR DESCRIPTION
partially fixes: https://github.com/nulib/repodev_planning_and_docs/issues/249

This does not address the search filters, which was broken out into a separate issue.

* Don't return collections that aren't `NUL Collection` types from Collection searches

*** **_Developers should note that no collections will show in their development Glaze application unless they are members of `NUL Collection` Collection types**