### PR TITLE
Add 'top_level' condition to collection and admin set queries

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -55,7 +55,8 @@ export async function getAdminSetItems(id, numResults = PAGE_SIZE) {
         bool: {
           must: [
             { match: { 'model.name': 'Image' } },
-            { match: { 'admin_set.id': id } }
+            { match: { 'admin_set.id': id } },
+            { match: { 'collection.top_level': true } }
           ]
         }
       },
@@ -145,7 +146,8 @@ export async function getCollectionItems(id, numResults = PAGE_SIZE) {
         bool: {
           must: [
             { match: { 'model.name': 'Image' } },
-            { match: { 'collection.id': id } }
+            { match: { 'collection.id': id } },
+            { match: { 'collection.top_level': true } }
           ]
         }
       },
@@ -210,33 +212,6 @@ export async function getTotalItemCount() {
     });
 
     return response.hits.total;
-  } catch (e) {
-    return Promise.resolve(0);
-  }
-}
-
-export async function getMemberIdsForImages(id) {
-  try {
-    const response = await search({
-      ...getObjBase,
-      body: {
-        query: [
-          { match: { 'model.name': 'Image' } },
-          { match: { 'collection.id': id } }
-        ],
-        size: 0,
-        aggs: {
-          members: {
-            terms: { field: 'member_ids.keyword', size: 10000 }
-          }
-        }
-      }
-    });
-    const members = response.aggregations.members.buckets.map(
-      member => member.key
-    );
-
-    return members;
   } catch (e) {
     return Promise.resolve(0);
   }

--- a/src/components/Collection/Collection.js
+++ b/src/components/Collection/Collection.js
@@ -60,8 +60,7 @@ export class Collection extends Component {
     error: null,
     items: null,
     loading: true,
-    showSidebar: false,
-    excludes: null
+    showSidebar: false
   };
 
   componentDidMount() {
@@ -92,8 +91,8 @@ export class Collection extends Component {
   }
 
   defaultQuery = () => {
-    const { collection, excludes } = this.state;
-    return collection ? collectionDefaultQuery(collection.id, excludes) : null;
+    const { collection } = this.state;
+    return collection ? collectionDefaultQuery(collection.id) : null;
   };
 
   getApiData(id) {
@@ -108,8 +107,6 @@ export class Collection extends Component {
     const request = async () => {
       const response = await elasticsearchApi.getCollection(id);
       let error = null;
-
-      const member_ids = await elasticsearchApi.getMemberIdsForImages(id);
 
       // Handle errors
       // Generic error
@@ -134,7 +131,6 @@ export class Collection extends Component {
 
       this.setState({
         collection: response._source,
-        excludes: member_ids,
         error,
         loading: false
       });
@@ -181,7 +177,7 @@ export class Collection extends Component {
   }
 
   render() {
-    const { collection, error, loading, showSidebar, excludes } = this.state;
+    const { collection, error, loading, showSidebar } = this.state;
     const { isMobile } = this.props;
     const breadCrumbData = collection
       ? this.createBreadcrumbData(collection)
@@ -214,14 +210,13 @@ export class Collection extends Component {
         return null;
       }
 
-      if (collection && excludes) {
+      if (collection) {
         return (
           <div>
             <FacetsSidebar
               facets={imageFacetsNoCollection}
               filters={allFilters}
               showSidebar={showSidebar}
-              excludes={excludes}
             />
             <main
               id="main-content"

--- a/src/components/UI/FacetsSidebar.js
+++ b/src/components/UI/FacetsSidebar.js
@@ -16,8 +16,7 @@ class FacetsSidebar extends Component {
     location: PropTypes.object, // provided by { withRouter }
     match: PropTypes.object, // provided by { withRouter }
     searchValue: PropTypes.string,
-    showSidebar: PropTypes.bool,
-    excludes: PropTypes.array
+    showSidebar: PropTypes.bool
   };
 
   isSearchPage = () => {
@@ -25,10 +24,7 @@ class FacetsSidebar extends Component {
   };
 
   collectionsQuery = () => {
-    return collectionDefaultQuery(
-      this.props.match.params.id,
-      this.props.excludes
-    );
+    return collectionDefaultQuery(this.props.match.params.id);
   };
 
   render() {

--- a/src/services/reactive-search.js
+++ b/src/services/reactive-search.js
@@ -84,18 +84,14 @@ export const imagesOnlyDefaultQuery = () => {
   };
 };
 
-export const collectionDefaultQuery = (collectionId, excludes = []) => {
+export const collectionDefaultQuery = collectionId => {
   return {
     query: {
       bool: {
-        must: {
-          match: { 'collection.id': collectionId }
-        },
-        must_not: {
-          terms: {
-            _id: excludes
-          }
-        }
+        must: [
+          { match: { 'collection.id': collectionId } },
+          { match: { 'collection.top_level': true } }
+        ]
       }
     }
   };


### PR DESCRIPTION
* Adjust Glaze queries in the collection search and in the collection/admin set photo grids to only return parent works. 

* Remove query that filters by member_ids to find parents (performance issue)

NOTES:
• This relies on each image being in one and only one NUL Collection. If/when that changes - we'll need to revisit. 
• Can't be deployed to production until after https://github.com/nulib/donut/issues/473 is deployed and indexed