### PR TITLE
Escape double quotes in global search bar

### DIFF
--- a/src/components/UI/Header/GlobalSearch.js
+++ b/src/components/UI/Header/GlobalSearch.js
@@ -14,11 +14,19 @@ class GlobalSearch extends Component {
     }
   }
 
+  escapeDoubleQuotes(str) {
+    return str.replace(/["]+/g, '%5C"');
+  }
+
   handleSubmit = e => {
+    const { searchValue } = this.state;
+
     e.preventDefault();
     this.props.history.push({
       pathname: `/search`,
-      search: `?q="${this.state.searchValue.split(' ').join('+')}"`
+      search: `?q="${this.escapeDoubleQuotes(searchValue)
+        .split(' ')
+        .join('+')}"`
     });
   };
 


### PR DESCRIPTION
This now fixes (escapes) double quotes in global search bar.