### PR TITLE
Change collection items query to top_level false

### DIFF
--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -55,9 +55,9 @@ export async function getAdminSetItems(id, numResults = PAGE_SIZE) {
         bool: {
           must: [
             { match: { "model.name": "Image" } },
-            { match: { "admin_set.id": id } },
-            { match: { "collection.top_level": true } }
-          ]
+            { match: { "admin_set.id": id } }
+          ],
+          must_not: [{ match: { "collection.top_level": false } }]
         }
       },
       ...sortKey
@@ -151,9 +151,9 @@ export async function getCollectionItems(id, numResults = PAGE_SIZE) {
         bool: {
           must: [
             { match: { "model.name": "Image" } },
-            { match: { "collection.id": id } },
-            { match: { "collection.top_level": true } }
-          ]
+            { match: { "collection.id": id } }
+          ],
+          must_not: { match: { "collection.top_level": false } }
         }
       },
       ...sortKey

--- a/src/services/reactive-search.js
+++ b/src/services/reactive-search.js
@@ -88,10 +88,8 @@ export const collectionDefaultQuery = collectionId => {
   return {
     query: {
       bool: {
-        must: [
-          { match: { "collection.id": collectionId } },
-          { match: { "collection.top_level": true } }
-        ]
+        must: { match: { "collection.id": collectionId } },
+        must_not: { match: { "collection.top_level": false } }
       }
     }
   };


### PR DESCRIPTION
• `top_level: true` was breaking Glaze when `top_level` info was not present. (No items were showing on collection pages)
• All works should have this info since they are in Collections but our indexing failed. Either way, Glaze shouldn't break if in this case