### PR TITLE
Add support for a custom OpenSeadragon thumbnail bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@nulib/prettier-config": "^1.2.0",
     "@testing-library/jest-dom": "^4.0.0",
     "@testing-library/react": "^8.0.8",
+    "@types/jest": "^24.0.20",
     "coveralls": "^3.0.5",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-prettier": "^3.1.0",

--- a/src/api/__mocks__/index.js
+++ b/src/api/__mocks__/index.js
@@ -1,0 +1,59 @@
+export function getManifest(url) {
+  return new Promise((resolve, reject) => {
+    process.nextTick(() =>
+      resolve({
+        sequences: [
+          {
+            canvases: [
+              {
+                label: "Label Number 1",
+                images: [
+                  {
+                    resource: {
+                      "@type": "dctypes:Image",
+                      "@id":
+                        "https://iiif.stack.rdc.library.northwestern.edu/1",
+                      height: 480,
+                      width: 640,
+                      format: null
+                    }
+                  }
+                ]
+              },
+              {
+                label: "Label Number 2",
+                images: [
+                  {
+                    resource: {
+                      "@type": "dctypes:Image",
+                      "@id":
+                        "https://iiif.stack.rdc.library.northwestern.edu/2",
+                      height: 480,
+                      width: 640,
+                      format: null
+                    }
+                  }
+                ]
+              },
+              {
+                label: "Label Number 3",
+                images: [
+                  {
+                    resource: {
+                      "@type": "dctypes:Image",
+                      "@id":
+                        "https://iiif.stack.rdc.library.northwestern.edu/3",
+                      height: 480,
+                      width: 640,
+                      format: null
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      })
+    );
+  });
+}

--- a/src/components/Work/OpenSeadragon/Thumbnails.js
+++ b/src/components/Work/OpenSeadragon/Thumbnails.js
@@ -1,0 +1,37 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const WorkOpenSeadragonThumbnails = ({ tileSources = [], onThumbClick }) => {
+  return (
+    <div
+      data-testid="open-seadragon-thumbnails-container"
+      className="bottom-panel"
+    >
+      <div className="thumbnail-view">
+        <ul className="panel-listing-thumbs">
+          {tileSources.map(t => (
+            <li
+              key={t.id}
+              data-testid="fileset-thumbnail"
+              onClick={() => onThumbClick(t.id)}
+              aria-label="Thumbnail"
+            >
+              <img
+                src={`${t.id}/square/70,70/0/default.jpg`}
+                className="thumbnail-image"
+                alt={t.label}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+WorkOpenSeadragonThumbnails.propTypes = {
+  onThumbClick: PropTypes.func,
+  tileSources: PropTypes.array
+};
+
+export default WorkOpenSeadragonThumbnails;

--- a/src/components/Work/OpenSeadragon/Thumbnails.test.js
+++ b/src/components/Work/OpenSeadragon/Thumbnails.test.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import WorkOpenSeadragonThumbnails from "./Thumbnails";
+
+const mockOnThumbClick = jest.fn();
+
+const tileSources = [
+  {
+    id: "https://iiif.stack.rdc.library.northwestern.edu/1",
+    label: "Fileset 1"
+  },
+  {
+    id: "https://iiif.stack.rdc.library.northwestern.edu/2",
+    label: "Fileset 2"
+  },
+  {
+    id: "https://iiif.stack.rdc.library.northwestern.edu/3",
+    label: "Fileset 3"
+  }
+];
+
+describe("WorkOpenSeadragonThumbnails component", () => {
+  function setUp() {
+    return render(
+      <WorkOpenSeadragonThumbnails
+        tileSources={tileSources}
+        onThumbClick={mockOnThumbClick}
+      />
+    );
+  }
+
+  it("renders without crashing", () => {
+    const { container } = render(<WorkOpenSeadragonThumbnails />);
+    expect(container).toBeTruthy();
+  });
+
+  it("renders thumbnails container", () => {
+    const { getByTestId } = setUp();
+    expect(
+      getByTestId("open-seadragon-thumbnails-container")
+    ).toBeInTheDocument();
+    expect();
+  });
+
+  it("renders the correct number of thumbnails", () => {
+    const { queryAllByTestId } = setUp();
+    expect(queryAllByTestId("fileset-thumbnail")).toHaveLength(3);
+  });
+});

--- a/src/components/Work/OpenSeadragon/Viewer.js
+++ b/src/components/Work/OpenSeadragon/Viewer.js
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
-import OpenSeadragon from 'openseadragon';
-import PropTypes from 'prop-types';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { MOBILE_BREAKPOINT } from '../../services/global-vars';
-import withSizes from 'react-sizes';
+import React, { Component } from "react";
+import OpenSeadragon from "openseadragon";
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { MOBILE_BREAKPOINT } from "../../../services/global-vars";
+import withSizes from "react-sizes";
+import WorkOpenSeadragonThumbnails from "./Thumbnails";
 
 class OpenSeadragonViewer extends Component {
   constructor(props) {
@@ -12,6 +13,7 @@ class OpenSeadragonViewer extends Component {
   }
 
   static propTypes = {
+    isMobile: PropTypes.bool,
     itemTitle: PropTypes.string,
     rightsStatement: PropTypes.object,
     tileSources: PropTypes.array
@@ -23,17 +25,17 @@ class OpenSeadragonViewer extends Component {
 
   componentDidMount() {
     let { tileSources } = this.props;
-    this.loadOpenSeadragon(tileSources);
+    this.loadOpenSeadragon(tileSources.map(t => t.id));
   }
 
   componentWillUnmount() {
-    this.openSeadragonInstance.removeHandler('open');
+    this.openSeadragonInstance.removeHandler("open");
   }
 
   buildDownloadLink = obj => {
     // TODO: Figure out a better way to find the event which fires when this is ready
     setTimeout(() => {
-      let img = this.openSeadragonInstance.drawer.canvas.toDataURL('image/png');
+      let img = this.openSeadragonInstance.drawer.canvas.toDataURL("image/png");
       this.setState({ downloadLink: img });
     }, 3000);
   };
@@ -42,33 +44,33 @@ class OpenSeadragonViewer extends Component {
     const { rightsStatement } = this.props;
 
     return (
-      rightsStatement.hasOwnProperty('uri') &&
-      rightsStatement.uri === 'http://rightsstatements.org/vocab/NoC-US/1.0/'
+      rightsStatement.hasOwnProperty("uri") &&
+      rightsStatement.uri === "http://rightsstatements.org/vocab/NoC-US/1.0/"
     );
   }
 
   loadOpenSeadragon(tileSources = []) {
     const customControlIds = {
-      zoomInButton: 'zoom-in',
-      zoomOutButton: 'zoom-out',
-      homeButton: 'home',
-      fullPageButton: 'full-page',
-      nextButton: 'next',
-      previousButton: 'previous'
+      zoomInButton: "zoom-in",
+      zoomOutButton: "zoom-out",
+      homeButton: "home",
+      fullPageButton: "full-page",
+      nextButton: "next",
+      previousButton: "previous"
     };
 
     this.openSeadragonInstance = OpenSeadragon({
-      id: 'openseadragon1',
-      crossOriginPolicy: 'use-credentials',
+      id: "openseadragon1",
+      crossOriginPolicy: "use-credentials",
       loadTilesWithAjax: true,
       ajaxWithCredentials: true,
       preserveViewport: true,
       defaultZoomLevel: 0,
-      referenceStripScroll: 'vertical',
+      referenceStripScroll: "vertical",
       sequenceMode: true,
       showNavigator: true,
-      showReferenceStrip: true,
-      toolbar: 'toolbarDiv',
+      showReferenceStrip: false,
+      toolbar: "toolbarDiv",
       tileSources,
       visibilityRatio: 1,
       gestureSettingsMouse: {
@@ -81,13 +83,20 @@ class OpenSeadragonViewer extends Component {
     });
 
     // Event listener for when OpenSeadragon's file are 'ready'
-    this.openSeadragonInstance.addHandler('open', this.buildDownloadLink);
+    this.openSeadragonInstance.addHandler("open", this.buildDownloadLink);
   }
+
+  handleThumbClick = id => {
+    const clickedIndex = this.props.tileSources.findIndex(
+      element => element.id === id
+    );
+    this.openSeadragonInstance.goToPage(clickedIndex);
+  };
 
   render() {
     const { downloadLink } = this.state;
-    const downloadTitle = `${this.props.itemTitle.split(' ').join('-')}.png`;
-    const { isMobile } = this.props;
+    const downloadTitle = `${this.props.itemTitle.split(" ").join("-")}.png`;
+    const { isMobile, tileSources } = this.props;
 
     return (
       <div>
@@ -141,6 +150,13 @@ class OpenSeadragonViewer extends Component {
         </div>
 
         <div id="openseadragon1" className="open-seadragon-container" />
+
+        {tileSources.length > 1 && (
+          <WorkOpenSeadragonThumbnails
+            onThumbClick={this.handleThumbClick}
+            tileSources={tileSources}
+          />
+        )}
       </div>
     );
   }

--- a/src/screens/Work/OpenSeadragonContainer.js
+++ b/src/screens/Work/OpenSeadragonContainer.js
@@ -1,19 +1,19 @@
-import React, { Component } from 'react';
-import OpenSeadragonViewer from '../../components/Work/OpenSeadragonViewer';
-import PropTypes from 'prop-types';
-import { getTileSources } from '../../services/iiif-parser';
-import { getManifest } from '../../api';
-import LoadingSpinner from '../../components/UI/LoadingSpinner';
-import { getESTitle } from '../../services/elasticsearch-parser';
+import React, { Component } from "react";
+import OpenSeadragonViewer from "../../components/Work/OpenSeadragon/Viewer";
+import PropTypes from "prop-types";
+import { getTileSources } from "../../services/iiif-parser";
+import { getManifest } from "../../api";
+import LoadingSpinner from "../../components/UI/LoadingSpinner";
+import { getESTitle } from "../../services/elasticsearch-parser";
 
 const styles = {
   spinner: {
-    padding: '50px 0'
+    padding: "50px 0"
   },
   wrapper: {
-    background: '#342f2e',
-    position: 'relative',
-    textAlign: 'center'
+    background: "#342f2e",
+    position: "relative",
+    textAlign: "center"
   }
 };
 
@@ -58,17 +58,17 @@ class OpenSeadragonContainer extends Component {
    * This also assumes that local DONUT instance is running on port 3000.
    */
   getEnvironmentManifestUrl(url) {
-    if (process.env.REACT_APP_LIVE_IIIF === 'true') {
+    if (process.env.REACT_APP_LIVE_IIIF === "true") {
       return url;
     }
 
     if (
-      process.env.NODE_ENV === 'development' ||
-      url.indexOf('http://devbox.library.northwestern.edu') > -1
+      process.env.NODE_ENV === "development" ||
+      url.indexOf("http://devbox.library.northwestern.edu") > -1
     ) {
-      const publicIndex = url.indexOf('/public');
+      const publicIndex = url.indexOf("/public");
       return (
-        url.slice(0, publicIndex) + ':3000' + url.slice(publicIndex, url.length)
+        url.slice(0, publicIndex) + ":3000" + url.slice(publicIndex, url.length)
       );
     }
     return url;

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -48,6 +48,11 @@ function getIIIFRootUrl(manifest) {
   return iiifRootUrl;
 }
 
+/**
+ * Extract tile source urls from a IIIF manifest
+ * @param {object} manifest
+ * @returns {array}
+ */
 export function getTileSources(manifest) {
   let tileSources = [];
 
@@ -57,7 +62,10 @@ export function getTileSources(manifest) {
 
   manifest.sequences[0].canvases.forEach(canvas => {
     if (canvas.images.length > 0 && canvas.images[0].resource) {
-      tileSources.push(canvas.images[0].resource.service["@id"]);
+      tileSources.push({
+        id: canvas.images[0].resource.service["@id"],
+        label: canvas.label
+      });
     }
   });
 

--- a/src/styles/sass/nulib-collections/_open-seadragon.scss
+++ b/src/styles/sass/nulib-collections/_open-seadragon.scss
@@ -29,6 +29,48 @@ a.toolbar-controls {
   }
 }
 
+// Thumbnails
+.bottom-panel {
+  background-color: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 110px;
+  z-index: 4;
+  overflow: hidden;
+  transition: transform 0.3s ease;
+}
+.thumbnail-view {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  overflow-x: scroll;
+  overflow-y: hidden;
+}
+.panel-listing-thumbs {
+  clear: both;
+  list-style: none;
+  padding: 0;
+  white-space: nowrap;
+  margin-top: 10px;
+  margin-bottom: 4px;
+
+  li {
+    box-sizing: border-box;
+    padding: 0 10px 0 10px;
+    display: inline-block;
+  }
+
+  img {
+    margin: 3px;
+    &:hover {
+      outline: 3px solid $nu-purple-30;
+      cursor: pointer;
+    }
+  }
+}
+
 @media screen and (max-width: 768px) {
   a.toolbar-controls {
     font-size: 1.25rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,6 +1443,18 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.20":
+  version "24.0.20"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.20.tgz#729d5fe8684e7fb06368d3bd557ac6d91289d861"
+  integrity sha512-M8ebEkOpykGdLoRrmew7UowTZ1DANeeP0HiSIChl/4DGgmnSC1ntitNtkyNSXjMTsZvXuaxJrxjImEnRWNPsPw==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"


### PR DESCRIPTION
This is the first step in building up custom thumbnail / label navigation for multiple filesets within a work.   Will continue to extend it...

![image](https://user-images.githubusercontent.com/3020266/67809259-68995c00-fa66-11e9-926c-76a5d555fb54.png)
