### PR TITLE
Update OpenSeadragon select options to read 'x of x: [fileset label]'

### DIFF
--- a/src/components/Work/OpenSeadragon/FilesetSelect.js
+++ b/src/components/Work/OpenSeadragon/FilesetSelect.js
@@ -6,7 +6,9 @@ const WorkOpenSeadragonFilesetSelect = ({
   onFileSetChange,
   tileSources = []
 }) => {
-  if (!currentTileSource || tileSources.length < 2) return null;
+  const tileSourcesCount = tileSources.length;
+
+  if (!currentTileSource || tileSourcesCount < 2) return null;
 
   return (
     <form className="web-form open-seadgragon-fileset-select-form">
@@ -17,7 +19,7 @@ const WorkOpenSeadragonFilesetSelect = ({
       >
         {tileSources.map((t, index) => (
           <option key={t.id} value={t.id}>
-            {`page ${index + 1}: ${t.label}`}
+            {`${index + 1} of ${tileSourcesCount}: ${t.label}`}
           </option>
         ))}
       </select>

--- a/src/components/Work/OpenSeadragon/FilesetSelect.test.js
+++ b/src/components/Work/OpenSeadragon/FilesetSelect.test.js
@@ -46,6 +46,18 @@ describe("WorkOpenSeadragonFilesetSelect", () => {
     expect(select.children.length).toEqual(3);
   });
 
+  it("renders the right information in select options", () => {
+    const { getByTestId } = setUpTest();
+    const select = getByTestId("filesets-select");
+    const options = select.children;
+
+    expect(options[1].value).toEqual(tileSources[1].id);
+    expect(options[1].innerHTML).toEqual(`2 of 3: ${tileSources[1].label}`);
+
+    expect(options[2].value).toEqual(tileSources[2].id);
+    expect(options[2].innerHTML).toEqual(`3 of 3: ${tileSources[2].label}`);
+  });
+
   it("calls back a function when select value changes", () => {
     const { getByTestId } = setUpTest();
     fireEvent.change(getByTestId("filesets-select"));


### PR DESCRIPTION
Now looks like:

![image](https://user-images.githubusercontent.com/3020266/68489467-c4a17480-020c-11ea-9f61-8ea5f0c6fe4d.png)
