### PR TITLE
Remove self work references on Item Details page so a work is not inc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "analyze": "source-map-explorer build/static/js/main.*",
     "build-css": "node-sass-chokidar src/ -o src/",
     "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive",
-    "start-js": "HOST=devbox.library.northwestern.edu PORT=3333 react-scripts start",
+    "start-js": "HOST=devbox.library.northwestern.edu PORT=3333 react-scripts start --no-cache",
     "start": "npm-run-all -p watch-css start-js",
     "start:use-real-data": "export REACT_APP_DONUT_URL=https://donut.library.northwestern.edu/ && export REACT_APP_ELASTICSEARCH_PROXY_BASE=https://5et90kbva4.execute-api.us-east-1.amazonaws.com/latest/ && export REACT_APP_LIVE_IIIF=true && npm-run-all -p watch-css start-js",
     "build-js": "react-scripts build",

--- a/src/components/Work/Work.js
+++ b/src/components/Work/Work.js
@@ -78,6 +78,10 @@ export class Work extends Component {
     let adminSetItems = await this.getAdminSets(item.admin_set.id);
     let collectionItems = await this.getCollections(item);
 
+    // Ensure current work is not also included in related works
+    adminSetItems = adminSetItems.filter(item => item.id !== id);
+    collectionItems = collectionItems.filter(item => item.id !== id);
+
     this.setState({
       adminSetItems: shuffleArray(adminSetItems),
       collectionItems,


### PR DESCRIPTION
…luded in related works.   Also included in this PR is an addition to the `yarn start` command which will make breakpoints work again in Dev console in Chromium browsers.

**Before:** 
![image](https://user-images.githubusercontent.com/3020266/71690580-c437dc80-2d6a-11ea-82f4-0926c5f6f48a.png)


**After:**
![image](https://user-images.githubusercontent.com/3020266/71690537-a1a5c380-2d6a-11ea-9110-aed7c0478ef8.png)
