### PR TITLE
Add style mixin to handle consistent scrollbars and sizing cross-brow…

### DIFF
--- a/src/styles/sass/nulib-collections/_mixins.scss
+++ b/src/styles/sass/nulib-collections/_mixins.scss
@@ -16,10 +16,37 @@
 
 // Collapsible arrows
 @mixin collapsible-down-arrow() {
-  background: url(images/arrow-right-dkpurple.svg) no-repeat 0.5rem center/8px 16px;
-  padding: .5em 0 .5rem 2rem;
+  background: url(images/arrow-right-dkpurple.svg) no-repeat 0.5rem center/8px
+    16px;
+  padding: 0.5em 0 0.5rem 2rem;
   border: none;
 }
 @mixin collapsible-right-arrow() {
-  background: url(images/arrow-down-dkpurple.svg) no-repeat 0.3rem center/16px 8px;
+  background: url(images/arrow-down-dkpurple.svg) no-repeat 0.3rem center/16px
+    8px;
+}
+
+// Custom scrollbar for cross-browser consistency
+// https://css-tricks.com/the-current-state-of-styling-scrollbars/
+@mixin scrollbar() {
+  // --scrollbarBG: #bbb8b8;
+  --scrollbarBG: #342f2e;
+  --thumbBG: #716c6b;
+
+  &::-webkit-scrollbar {
+    width: 20px;
+  }
+
+  scrollbar-width: auto;
+  scrollbar-color: var(--thumbBG) var(--scrollbarBG);
+
+  &::-webkit-scrollbar-track {
+    background: var(--scrollbarBG);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--thumbBG);
+    border-radius: 6px;
+    border: 3px solid var(--scrollbarBG);
+  }
 }

--- a/src/styles/sass/nulib-collections/_open-seadragon.scss
+++ b/src/styles/sass/nulib-collections/_open-seadragon.scss
@@ -32,7 +32,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  height: 110px;
+  height: 130px;
   z-index: 4;
   overflow: hidden;
   transition: transform 0.3s ease;
@@ -43,13 +43,14 @@
   width: 100%;
   overflow-x: scroll;
   overflow-y: hidden;
+  @include scrollbar;
 }
 .panel-listing-thumbs {
   clear: both;
   list-style: none;
   padding: 0;
   white-space: nowrap;
-  margin-top: 10px;
+  margin-top: 13px;
   margin-bottom: 4px;
 
   .active-thumb {


### PR DESCRIPTION
…ser for Openseadragon thumbnails

Added a Sass `scrollbar` mixin we can reuse where needed.  This fix adds a bit more breathing room to the OpenSeadragon thumbnails, by making the scrollbar coloring and size consistent cross-browser.

Tested in Browserstack and locally cross browser.


**After**
![image](https://user-images.githubusercontent.com/3020266/71731122-8dfd6a00-2e09-11ea-95b0-43009261b279.png)

**Before**
![image](https://user-images.githubusercontent.com/3020266/71731218-c604ad00-2e09-11ea-9bac-c19f4e03bf99.png)
