### PR TITLE
Cleaned out a lot of redundancy between the Item Details Screen and C…

### DIFF
--- a/src/components/Work/ParentCollections.js
+++ b/src/components/Work/ParentCollections.js
@@ -1,75 +1,63 @@
-import React, { Component } from 'react';
-import PhotoGrid from '../UI/PhotoGrid';
-import PropTypes from 'prop-types';
-import ThisItem from './ThisItem';
-import SectionTop from '../UI/SectionTop';
-import { facetValues } from '../../services/reactive-search';
-import { getCollection } from '../../api/elasticsearch-api';
-import { getESTitle } from '../../services/elasticsearch-parser';
+import React from "react";
+import PhotoGrid from "../UI/PhotoGrid";
+import PropTypes from "prop-types";
+import ThisItem from "./ThisItem";
+import SectionTop from "../UI/SectionTop";
+import { facetValues } from "../../services/reactive-search";
 
-class ParentCollections extends Component {
-  state = {
-    collectionTitle: ''
-  };
+const ParentCollections = ({ adminSetItems = [], collection, item }) => {
+  const adminSetTitle = item.admin_set ? item.admin_set.title[0] : "";
 
-  async componentDidMount() {
-    let collection = await getCollection(this.props.collectionId);
-    this.setState({ collectionTitle: getESTitle(collection._source) });
-  }
-
-  render() {
-    const { collectionTitle } = this.state;
-    const { adminSetItems, collectionId, collectionItems, item } = this.props;
-    const adminSetTitle = item.admin_set ? item.admin_set.title[0] : '';
-
-    return (
-      <div>
-        {item && adminSetItems && (
-          <section className="section">
-            <SectionTop
-              sectionTitle="Library Department"
-              optionalSubhead={adminSetTitle}
-              optionalButtons={[
-                {
-                  label: 'View All Items in Library Department',
-                  url: '/search',
-                  state: {
-                    facetValue: facetValues.LIBRARY_DEPARTMENT,
-                    searchValue: adminSetTitle
-                  }
+  return (
+    <div>
+      {item && adminSetItems && (
+        <section className="section">
+          <SectionTop
+            sectionTitle="Library Department"
+            optionalSubhead={adminSetTitle}
+            optionalButtons={[
+              {
+                label: "View All Items in Library Department",
+                url: "/search",
+                state: {
+                  facetValue: facetValues.LIBRARY_DEPARTMENT,
+                  searchValue: adminSetTitle
                 }
-              ]}
-            />
-            <PhotoGrid items={adminSetItems} hideDescriptions={true} />
-          </section>
-        )}
+              }
+            ]}
+          />
+          <PhotoGrid items={adminSetItems} hideDescriptions={true} />
+        </section>
+      )}
 
-        {item && collectionItems.length > 0 && (
-          <section>
-            <SectionTop
-              sectionTitle="Collection"
-              optionalSubhead={collectionTitle}
-              optionalButtons={[
-                {
-                  label: 'View All Items in Collection',
-                  url: `/collections/${collectionId}`
-                }
-              ]}
-            />
-            <PhotoGrid items={collectionItems} />
-          </section>
-        )}
+      {item && collection.items.length > 0 && (
+        <section>
+          <SectionTop
+            sectionTitle="Collection"
+            optionalSubhead={collection.title}
+            optionalButtons={[
+              {
+                label: "View All Items in Collection",
+                url: `/collections/${collection.id}`
+              }
+            ]}
+          />
+          <PhotoGrid items={collection.items} />
+        </section>
+      )}
 
-        <ThisItem item={item} />
-      </div>
-    );
-  }
-}
+      <ThisItem item={item} />
+    </div>
+  );
+};
 
 ParentCollections.propTypes = {
   adminSetItems: PropTypes.array.isRequired,
-  collectionId: PropTypes.string.isRequired,
-  collectionItems: PropTypes.array.isRequired,
+  collection: PropTypes.shape({
+    id: PropTypes.string,
+    title: PropTypes.string,
+    items: PropTypes.array
+  }),
   item: PropTypes.object.isRequired
 };
 

--- a/src/components/Work/Work.js
+++ b/src/components/Work/Work.js
@@ -1,8 +1,5 @@
-import React, { Component } from "react";
-import { withRouter } from "react-router";
-import { connect } from "react-redux";
+import React, { useState, useEffect } from "react";
 import * as elasticsearchApi from "../../api/elasticsearch-api.js";
-import ErrorSection from "../UI/ErrorSection";
 import ItemDetail from "../../components/Work/ItemDetail";
 import * as elasticsearchParser from "../../services/elasticsearch-parser";
 import * as globalVars from "../../services/global-vars";
@@ -10,51 +7,33 @@ import LoadingSpinner from "../UI/LoadingSpinner";
 import { shuffleArray } from "../../services/helpers";
 import ParentCollections from "../../components/Work/ParentCollections";
 import LargeFeature from "../../components/Work/LargeFeature";
-import { loadDataLayer } from "../../services/google-tag-manager";
-import { loadItemStructuredData } from "../../services/google-structured-data";
+import PropTypes from "prop-types";
 
-export class Work extends Component {
-  constructor(props) {
-    super(props);
+const Work = ({ work }) => {
+  const [adminSetItems, setAdminSetItems] = useState([]);
+  const [collection, setCollection] = useState({
+    id: "",
+    title: "",
+    items: []
+  });
+  const [loading, setLoading] = useState(true);
 
-    this.state = {
-      adminSetItems: [],
-      collectionId: null,
-      collectionItems: [],
-      error: null,
-      id: null,
-      item: null,
-      loading: true,
-      structuredData: null
-    };
-  }
+  useEffect(() => {
+    async function getApiData() {
+      if (!work) {
+        return;
+      }
+      let adminSetItems = await getAdminSets(work.admin_set.id);
+      let collectionResponse = await getCollections(work);
 
-  async componentDidMount() {
-    this.getApiData(this.props.match.params.id);
-  }
-
-  componentDidUpdate(prevProps) {
-    if (!prevProps.location) {
-      return;
+      setAdminSetItems(shuffleArray(adminSetItems));
+      setCollection({ ...collectionResponse });
+      setLoading(false);
     }
-    if (prevProps.location.pathname !== this.props.location.pathname) {
-      this.getApiData(this.props.match.params.id);
-    }
-  }
+    getApiData();
+  }, [work]);
 
-  createBreadcrumbData(item) {
-    let crumbs = [{ title: "Items", link: "/search" }];
-
-    if (item) {
-      crumbs.push({
-        title: elasticsearchParser.getESTitle(item),
-        link: ""
-      });
-    }
-    return crumbs;
-  }
-
-  async getAdminSets(adminSetId) {
+  async function getAdminSets(adminSetId) {
     let adminSetResponse = await elasticsearchApi.getAdminSetItems(
       adminSetId,
       4
@@ -66,46 +45,13 @@ export class Work extends Component {
     );
   }
 
-  async getApiData(id) {
-    let item = await this.getItem(id);
-
-    if (!item) {
-      return;
-    }
-
-    this.populateGTMDataLayer(item);
-
-    let adminSetItems = await this.getAdminSets(item.admin_set.id);
-    let collectionItems = await this.getCollections(item);
-
-    // Ensure current work is not also included in related works
-    adminSetItems = adminSetItems.filter(item => item.id !== id);
-    collectionItems = collectionItems.filter(item => item.id !== id);
-
-    this.setState({
-      adminSetItems: shuffleArray(adminSetItems),
-      collectionItems,
-      id,
-      item,
-      loading: false,
-      structuredData: loadItemStructuredData(item, this.props.location.pathname)
-    });
-  }
-
-  async getCollections(item) {
-    const { collection } = item;
-
-    if (collection.length === 0) {
+  async function getCollections(work) {
+    if (work.collection.length === 0) {
       return [];
     }
 
-    // Pass this property down the tree for linking purposes in Show All Items in Collection
-    this.setState({
-      collectionId: collection[0].id
-    });
-
     let response = await elasticsearchApi.getCollectionItems(
-      collection[0].id,
+      work.collection[0].id,
       4
     );
     let items = elasticsearchParser.prepPhotoGridItems(
@@ -113,122 +59,29 @@ export class Work extends Component {
       globalVars.IMAGE_MODEL
     );
 
-    return items;
-  }
-
-  async getItem(id) {
-    let itemError = "";
-    let itemResponse = await elasticsearchApi.getItem(id);
-    const { error } = itemResponse;
-
-    // Handle possible errors
-    // Generic error
-    if (error) {
-      if (error.statusCode === 403) {
-        itemError = error.reason;
-      } else {
-        return this.handle404redirect(itemResponse.error.reason);
-      }
-    }
-    // Item not found
-    else if (!itemResponse.found) {
-      return this.handle404redirect();
-    }
-    // Restricted item
-    else if (itemResponse._source.visibility === "restricted") {
-      itemError = `The current item's visibility is restricted.`;
-    }
-    // Authenticated
-    else if (
-      itemResponse._source.visibility === "authenticated" &&
-      !this.props.auth.token
-    ) {
-      itemError = `The current item's visibility is restricted to logged in users.`;
-    }
-
-    if (itemError) {
-      this.setState(
-        {
-          id: id,
-          item: null,
-          error: itemError,
-          loading: false
-        },
-        // Return a null value for item, indicating something went south
-        () => null
-      );
-    }
-
-    return itemResponse._source;
-  }
-
-  handle404redirect(
-    message = "There was an error retrieving the item, or the item id does not exist."
-  ) {
-    this.props.history.push(globalVars.ROUTES.PAGE_NOT_FOUND.path, {
-      message
-    });
-  }
-
-  populateGTMDataLayer(item) {
-    const rightsStatement = item.rights_statement
-      ? item.rights_statement.label
-      : "";
-    const creators = item.creator.map(creator => creator.label);
-    const contributors = item.contributor.map(contributor => contributor.label);
-
-    const dataLayer = {
-      adminset: item.admin_set.title.map(title => title).join(", "),
-      collections: item.collection.map(collection =>
-        collection.title.map(title => title).join(", ")
-      ),
-      creatorsContributors: [...creators, ...contributors],
-      pageTitle: elasticsearchParser.getESTitle(item),
-      rightsStatement,
-      subjects: item.subject.map(subject => subject.label),
-      visibility: item.visibility
+    return {
+      id: work.collection[0].id,
+      title: elasticsearchParser.getESTitle(work.collection[0]),
+      items
     };
-
-    loadDataLayer(dataLayer);
   }
 
-  render() {
-    const {
-      item,
-      error,
-      collectionId,
-      collectionItems,
-      adminSetItems,
-      loading
-    } = this.state;
+  return (
+    <div>
+      <LargeFeature item={work} />
+      <LoadingSpinner loading={loading} />
+      <ParentCollections
+        item={work}
+        adminSetItems={adminSetItems}
+        collection={collection}
+      />
+      <ItemDetail item={work} />
+    </div>
+  );
+};
 
-    if (error) {
-      return <ErrorSection message={error} />;
-    }
-    return (
-      <div>
-        <LoadingSpinner loading={loading} />
+Work.propTypes = {
+  work: PropTypes.object.isRequired
+};
 
-        {!loading && (
-          <div>
-            <LargeFeature item={item} />
-            <ParentCollections
-              item={item}
-              adminSetItems={adminSetItems}
-              collectionItems={collectionItems}
-              collectionId={collectionId}
-            />
-            <ItemDetail item={item} />
-          </div>
-        )}
-      </div>
-    );
-  }
-}
-
-const mapStateToProps = state => ({
-  auth: state.auth
-});
-
-const withRouterWork = withRouter(Work);
-export default connect(mapStateToProps)(withRouterWork);
+export default Work;

--- a/src/services/elasticsearch-parser.js
+++ b/src/services/elasticsearch-parser.js
@@ -74,8 +74,9 @@ export function getESTitle(_source) {
     return "";
   }
   const { title } = _source;
-  let titleArray = title.primary.map((title, i) => {
-    return i > 0 ? `, ${title}` : title;
+  const titles = title.primary || title;
+  let titleArray = titles.map((item, i) => {
+    return i > 0 ? `, ${item}` : item;
   });
 
   return titleArray.join("");


### PR DESCRIPTION
…omponent components.  In the process fixed the updating bug so that Collection will update with a change in Item on Item Details page.

So this PR does the following:
- Cleans up a lot of redundant code between Work components
- Transitions from Class components to functional hooks for a few components
- Moves work data fetching exclusively to `Screens/Work/Work` component
- And finally once everything was easier to see, fixes the bug of sticky Collection data hanging around when navigating across different Works.