### PR TITLE
Clean up display for Item Details metadata tabs on mobile devices

### DIFF
--- a/src/styles/sass/nulib-collections/_item-view.scss
+++ b/src/styles/sass/nulib-collections/_item-view.scss
@@ -181,6 +181,12 @@
   .cite-group-col {
     float: left;
     width: 50%;
+    word-break: break-word;
+
+    @media screen and (max-width: 768px) {
+      float: none;
+      width: 100%;
+    }
   }
   .cite-group {
     > p {

--- a/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
+++ b/src/styles/sass/nulib-collections/_nuwebcomm-overrides.scss
@@ -24,19 +24,25 @@
   display: block;
 }
 
+// Make tabs display a little nicer on mobile
+#tabs {
+  display: flex;
+  justify-content: center;
+}
+
 @media screen and (max-width: 768px) {
   .mobile-link {
     // Because we're using a <button> instead of <a>, for accessibility
     padding: 0;
 
     &.mobile-nav-link {
-      background: url('images/hamburger-purple.svg') no-repeat center/20px 20px;
+      background: url("images/hamburger-purple.svg") no-repeat center/20px 20px;
     }
     &.mobile-search-link {
-      background: url('images/search-purple.svg') no-repeat center/20px 20px;
+      background: url("images/search-purple.svg") no-repeat center/20px 20px;
 
       &.open {
-        background: #401f68 url('images/alert-x-white-home.svg') no-repeat
+        background: #401f68 url("images/alert-x-white-home.svg") no-repeat
           center/20px 20px;
       }
     }


### PR DESCRIPTION
Quick fix to responsive display.  Now looks like:

### After
![image](https://user-images.githubusercontent.com/3020266/73282012-79b54e80-41b6-11ea-867a-e57b0290c01b.png)

### Before
![image](https://user-images.githubusercontent.com/3020266/73282093-9fdaee80-41b6-11ea-8193-6978c8386c08.png)
