### PR TITLE
Fix for filtering on a Work's Folder and Box faceted links

### DIFF
--- a/src/components/Work/MetadataDisplay.js
+++ b/src/components/Work/MetadataDisplay.js
@@ -12,7 +12,7 @@ const MetadataDisplay = ({
   facet,
   external_url = "",
   collection,
-  folderNumber
+  boxNumber
 }) => {
   if (!items) return null;
 
@@ -23,21 +23,21 @@ const MetadataDisplay = ({
     let encoded = encodeURI(`${facet.value}=["${adjustedSearchValue}"]`);
     const collectionTitle = getESTitle(collection);
 
-    // Account for Folder
+    // Folder should filter on "collection", "box", and "folder" facets
     if (facet.value === "Folder") {
       encoded = encodeURI(
-        `Folder=["${adjustedSearchValue}"]&Collection=["${collectionTitle
-          .split(" ")
-          .join("+")}"]`
+        `Folder=["${adjustedSearchValue}"]&Box=["${
+          boxNumber[0]
+        }"]&Collection=["${collectionTitle.split(" ").join("+")}"]`
       );
     }
 
-    // Account for Box
+    // Box should only filter on "collection" and "box" facets
     if (facet.value === "Box") {
       encoded = encodeURI(
-        `Box=["${adjustedSearchValue}"]&Folder=["${
-          folderNumber[0]
-        }"]&Collection=["${collectionTitle.split(" ").join("+")}"]`
+        `Box=["${adjustedSearchValue}"]&Collection=["${collectionTitle
+          .split(" ")
+          .join("+")}"]`
       );
     }
 
@@ -101,7 +101,7 @@ MetadataDisplay.propTypes = {
   facet: PropTypes.object,
   external_url: PropTypes.string,
   collection: PropTypes.object,
-  folderNumber: PropTypes.array
+  boxNumber: PropTypes.array
 };
 
 export default MetadataDisplay;

--- a/src/components/Work/Tabs/Find.js
+++ b/src/components/Work/Tabs/Find.js
@@ -82,7 +82,7 @@ const TabsFind = ({ item }) => {
           facet={findItem.facet}
           external_url={findItem.external_url}
           collection={item.collection[0]}
-          folderNumber={folderNumber}
+          boxNumber={boxNumber}
         />
       ))}
     </div>


### PR DESCRIPTION
This fixes the logic (which I reversed in the original PR) for clicking on a Work's "Folder" and "Box" facet links on the Work Item Details page.

![image](https://user-images.githubusercontent.com/3020266/77177473-8efe7900-6a93-11ea-8b96-7cfb63ec671e.png)
