### PR TITLE
Gracefully handle logging out when on a page with authenticated content

### DIFF
--- a/src/components/UI/Nav/Login.js
+++ b/src/components/UI/Nav/Login.js
@@ -3,9 +3,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { isMobile } from "react-device-detect";
 import { forceLogout } from "../../../actions/auth";
 import * as nulApi from "../../../services/nul-api.js";
+import { useLocation, useHistory, useParams } from "react-router-dom";
 
 const Login = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
+  const location = useLocation();
   const authToken = useSelector(state => state.auth.token);
   const styles = {
     link: {
@@ -14,6 +17,31 @@ const Login = () => {
     },
     subNavLink: {
       display: "inline-block"
+    }
+  };
+
+  const handleLogout = () => {
+    dispatch(forceLogout());
+
+    try {
+      // Current screen is either Collection landing, or Work
+      // On logout, gracefully route back to homepage instead of an
+      // unauthorized message
+      const pathnameArray = location.pathname.slice(1).split("/");
+      const isCollectionScreen =
+        pathnameArray[0] === "collections" && pathnameArray[1];
+      const isItems = pathnameArray[0] === "items";
+
+      if (isCollectionScreen || isItems) {
+        history.push("/");
+      }
+
+      // Collection list screen.  Reload the page
+      if (pathnameArray[0] === "collections" && !pathnameArray[1]) {
+        window.location.reload(false);
+      }
+    } catch (error) {
+      console.log("Error in handleLogout in Login.js: ", error);
     }
   };
 
@@ -56,7 +84,7 @@ const Login = () => {
               <button
                 style={styles.subNavLink}
                 className="button-link"
-                onClick={() => dispatch(forceLogout())}
+                onClick={handleLogout}
               >
                 SIGN OUT
               </button>


### PR DESCRIPTION
@kdid Check this out and let me know if it works as you'd expect?

When on the Collection landing screen, or Work screen, a logout will redirect user back to the Home Screen.  This is the easiest solution, so we don't have to wire some Redux connectors to have the Login component know about a Collection or Work.

When on the Collections list screen, it refreshes the page.