### PR TITLE
Bug fix for OpenSeadragon not refreshing content when changing an ite…

### DIFF
--- a/src/components/UI/Nav/Login.js
+++ b/src/components/UI/Nav/Login.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { isMobile } from "react-device-detect";
 import { forceLogout } from "../../../actions/auth";
 import * as nulApi from "../../../services/nul-api.js";
-import { useLocation, useHistory, useParams } from "react-router-dom";
+import { useLocation, useHistory } from "react-router-dom";
 
 const Login = () => {
   const dispatch = useDispatch();

--- a/src/screens/Work/Work.js
+++ b/src/screens/Work/Work.js
@@ -16,7 +16,6 @@ import LoadingSpinner from "../../components/UI/LoadingSpinner";
 
 const ScreensWork = () => {
   const [error, setError] = useState();
-  const [id, setId] = useState();
   const [item, setItem] = useState();
   const [loading, setLoading] = useState();
   const [structuredData, setStructuredData] = useState();
@@ -30,12 +29,12 @@ const ScreensWork = () => {
   useEffect(() => {
     async function getApiData() {
       let item = await getItem();
+
       if (!item) {
         return;
       }
 
       populateGTMDataLayer(item);
-      setId(params.id);
       setItem(item);
       setLoading(false);
       setStructuredData(loadItemStructuredData(item, location.pathname));
@@ -111,7 +110,7 @@ const ScreensWork = () => {
 
   // This check ensures that when changing ids (items) on the same route, the "id" is different
   // at this point of execution
-  const idInSync = params.id === id;
+  const idInSync = item && params.id === item.id;
 
   const itemTitle = item ? elasticsearchParser.getESTitle(item) : "";
 

--- a/src/services/nul-api.js
+++ b/src/services/nul-api.js
@@ -43,14 +43,12 @@ async function iiifAuth(token) {
 }
 
 export async function extractApiToken(cookieStr) {
-  console.log("cookieStr", cookieStr);
   if (anonymous()) {
-    console.log("is anonymous()");
     return nullUser;
   }
 
   let ssoToken = cookies.parse(cookieStr).openAMssoToken;
-  console.log("ssoToken", ssoToken);
+
   if (ssoToken === null) return nullUser;
 
   try {


### PR DESCRIPTION
…m on the same route

On the Work page, when clicking on a related item, like another PhotoBox item in "Library Department" section of the page, the OpenSeadragon viewer was not refreshing content, even though rest of the page shows new Work data.

This was another regression bug.   Hooray Cypress to the future.