### PR TITLE
Modified pagination for infinite scroll

### DIFF
--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -137,10 +137,12 @@ const Search = ({ breadcrumbs = [] }) => {
           renderItem={renderItem}
           pagination={true}
           paginationAt="bottom"
+          pages={10}
           react={{
             and: allFilters
           }}
-          size={12}
+          showEndPage={true}
+          size={24}
           URLParams={true}
         />
       </main>


### PR DESCRIPTION
Removed infinite scroll and configured pagination to display end of results and better navigation between pages.

<img width="794" alt="Screen Shot 2020-03-27 at 10 37 39 AM" src="https://user-images.githubusercontent.com/14085957/77773310-6ccaa500-7017-11ea-9ba3-91a23eec75e8.png">

<img width="789" alt="Screen Shot 2020-03-27 at 10 42 01 AM" src="https://user-images.githubusercontent.com/14085957/77773449-a0a5ca80-7017-11ea-8186-1bc1d37ae383.png">

