### PR TITLE
Handle re-direction of legacy pids used by retired Images application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Next Generation Presentation Layer
+# Digital Collections application
 
 [![CircleCI](https://circleci.com/gh/nulib/next-gen-front-end-react.svg?style=svg)](https://circleci.com/gh/nulib/next-gen-front-end-react) [![Coverage Status](https://coveralls.io/repos/github/nulib/next-gen-front-end-react/badge.svg?branch=deploy/staging)](https://coveralls.io/github/nulib/next-gen-front-end-react?branch=deploy/staging)
 
-This ReactJS application serves as the presentation layer for Northwestern's Next Generation Repository. It contains discovery UI components for searching, filtering, browsing and navigation of items ingested through Hyrax.
+This ReactJS application serves as the presentation layer for Northwestern's Next Generation Repository. It contains discovery UI components for searching, filtering, browsing and navigating of items against an AWS Elasticsearch index.
 
 ## Getting Started
 
@@ -18,6 +18,7 @@ These instructions will get you a copy of the project up and running on your loc
 ```bash
 git clone git@github.com:nulib/next-gen-front-end-react.git
 cd next-gen-front-end-react
+
 git checkout deploy/staging
 yarn install
 ```
@@ -26,12 +27,28 @@ yarn install
 
 ### Start Docker containers
 
-- Open a terminal tab, navigate to your `donut` (https://github.com/nulib/donut) repository directory and start the Docker environment.
+Open a terminal tab, navigate to your `donut` (https://github.com/nulib/donut) repository directory and start the Docker environment.
 
 ```
 checkout deploy/staging
 devstack up donut glaze
 ```
+
+#### Elasticsearch
+
+If you'd like to view the Elasticsearch Production or Staging index while developing, run either of the following commands:
+
+```
+AWS_PROFILE=production es-proxy
+```
+
+or
+
+```
+AWS_PROFILE=staging es-proxy
+```
+
+The command will output a link, which you can copy and paste in your browser to view the Elasticsearch index, via Kibana.
 
 ### Start the React front-end application
 
@@ -98,7 +115,9 @@ Merging `deploy/staging` branch into `master` will automatically update the prod
 ## Built With
 
 - ReactJS - UI component library
-- Redux - state management
+- ReactiveSearch - Elasticsearch components library package
+- Jest - Unit testing
+- Cypress - End to End testing
 - Northwestern Global Marketing design templates
 
 ## Contributing

--- a/cypress/integration/persona_paths_spec.js
+++ b/cypress/integration/persona_paths_spec.js
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+describe("Persona paths", () => {
+  context("Anonymous user", () => {
+    context("Legacy pid url", () => {
+      const legacyPidRoute =
+        "/legacy-pid/inu:dil-c9c1ab35-8cfe-433e-91f4-a4749367216b";
+
+      it("redirects to the Digital Collections Work screen given a valid Legacy Pid value", () => {
+        cy.visit(legacyPidRoute);
+        cy.location("pathname").should("include", "/items");
+      });
+
+      it("redirects to the Home screen given an invalid Legacy Pid value", () => {
+        cy.visit("/legacy-pid/ABC123");
+        cy.location("pathname").should("be", "/");
+      });
+    });
+  });
+});

--- a/src/api/elasticsearch-api.js
+++ b/src/api/elasticsearch-api.js
@@ -187,6 +187,32 @@ export async function getItem(id) {
   }
 }
 
+export async function getLegacyPidItem(pid) {
+  try {
+    const response = await search({
+      ...getObjBase,
+      body: {
+        query: {
+          bool: {
+            must: [
+              {
+                match: {
+                  "legacy_identifier.keyword": pid
+                }
+              }
+            ]
+          }
+        }
+      }
+    });
+    const id = response.hits.hits[0]._source.id;
+    return id;
+  } catch (e) {
+    console.log(`Error in getLegacyPidItem(): ${e}`);
+    return Promise.resolve();
+  }
+}
+
 /**
  * Get all Work items from indexer
  * @param {Number} numResults - Function caller can specify how many results they want back

--- a/src/screens/Layout.js
+++ b/src/screens/Layout.js
@@ -20,6 +20,7 @@ import "../Layout.css";
 import "../libs/nuwebcomm-scripts.js";
 import { fetchApiToken } from "../actions/auth";
 import PropTypes from "prop-types";
+import ScreensLegacyPid from "./LegacyPid";
 
 const ReactiveBaseWrapper = props => {
   return (
@@ -86,6 +87,9 @@ export class Layout extends Component {
               <ScreensSearch />
             </ReactiveBaseWrapper>
           </Route>
+
+          <Route path={ROUTES.LEGACY_PID.path} component={ScreensLegacyPid} />
+
           <Route exact path={ROUTES.HOME.path} component={ScreensHome} />
           <Route path={ROUTES.PAGE_NOT_FOUND.path} component={Default404} />
           <Route component={Default404} />

--- a/src/screens/LegacyPid.js
+++ b/src/screens/LegacyPid.js
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from "react";
+import { Redirect, useParams } from "react-router-dom";
+import UILoadingSpinner from "../components/UI/LoadingSpinner";
+import { getLegacyPidItem } from "../api/elasticsearch-api";
+
+function ScreensLegacyPid() {
+  const [loading, setLoading] = useState(true);
+  const [id, setId] = useState();
+  const params = useParams();
+
+  useEffect(() => {
+    const fn = async () => {
+      const id = await getLegacyPidItem(params.pid);
+      setId(id);
+      setLoading(false);
+    };
+    fn();
+  }, [params.pid]);
+
+  return loading ? (
+    <UILoadingSpinner />
+  ) : (
+    <Redirect to={id ? `/items/${id}` : "/"} />
+  );
+}
+
+export default ScreensLegacyPid;

--- a/src/services/elasticsearch-parser.js
+++ b/src/services/elasticsearch-parser.js
@@ -113,20 +113,3 @@ export function prepPhotoGridItems(
     description: getESDescription(hit._source)
   }));
 }
-
-/**
- * Mapping of all possible work types Solr knows about, to how these work types are represented in a Hyrax URL
- * ie. 'Image' translates into 'images' in the following url: http://devbox.library.northwestern.edu/concern/images/7e2ca0a5-3a2e-4074-a475-944710e07b2f
- * @return {Map} An ES2015 Map, which is like an Object, but better suited here for a key/value store.
- */
-function getModelUriMap() {
-  let modelUriMap = new Map();
-  modelUriMap.set("Image", "images");
-  return modelUriMap;
-}
-
-export function getModelUriSegment(has_model_ssim) {
-  const modelUriMap = getModelUriMap();
-  const segment = modelUriMap.get(has_model_ssim[0]);
-  return segment;
-}

--- a/src/services/global-vars.js
+++ b/src/services/global-vars.js
@@ -98,6 +98,10 @@ export const ROUTES = {
     title: "",
     path: "/items/:id"
   },
+  LEGACY_PID: {
+    title: "",
+    path: "/legacy-pid/:pid"
+  },
   PAGE_NOT_FOUND: {
     title: "404 Page Not Found",
     path: "/notfound"


### PR DESCRIPTION
To handle redirections from the soon to be retired Images app, any incoming requests to Digital Collections which look like:

`https://[DC_ENVIRONMENT_URL]/legacy-pid/:pid`

(`pid` being the Images legacy identifier), will route to the proper DC Work screen.  If it's a bad `pid` value, it'll redirect to the DC Home screen.

@davidschober @mbklein  So whoever is setting up redirections from Images, use the pattern above.