### PR TITLE
Added Cypress E2E test for collection view page

### DIFF
--- a/cypress/integration/collections/view_page_spec.js
+++ b/cypress/integration/collections/view_page_spec.js
@@ -1,0 +1,167 @@
+/// <reference types="cypress" />
+
+//const jwt = require("jsonwebtoken");
+
+describe("Collections View page", () => {
+  context("Anonymous user", () => {
+    beforeEach(() => {
+      cy.visit("/collections/1c2e2200-c12d-4c7f-8b87-a935c349898a");
+    });
+    it("should display breadcrumbs", () => {
+      cy.getByTestId("breadcrumbs").within($breadcrumbs => {
+        cy.contains("Collections")
+          .should("have.attr", "href")
+          .and("include", "/collections");
+        cy.contains("16th-Early 20th Century Maps of Africa");
+      });
+    });
+
+    it("should display screen title, search box", () => {
+      cy.get("main").within($main => {
+        cy.contains("h2", "16th-Early 20th Century Maps of Africa");
+        cy.get("input.searchbox");
+        cy.get(".rs-results-info").contains("results found in");
+      });
+    });
+
+    it("should toggle filters/facets on/off", () => {
+      cy.getByTestId("button-filter-toggle").as("toggleButton");
+      cy.getByTestId("facets-sidebar")
+        .as("facetsSidebar")
+        .should("not.be.visible");
+      cy.get("@toggleButton").click();
+      cy.get("@toggleButton").should("contain.text", "Hide Filters");
+      cy.get("@facetsSidebar").contains("h2", "Filter By");
+      cy.get("@toggleButton").click();
+      cy.get("@facetsSidebar").should("not.be.visible");
+    });
+
+    it("should display sidebar", () => {
+      cy.get("#sidebar").within($sidebar => {
+        cy.contains("h3", "Collection Description");
+        cy.contains("p");
+      });
+    });
+
+    it("displays only public works in search results", () => {
+      cy.getByTestId("button-filter-toggle").click();
+      cy.contains("Visibility", { timeout: 15000 })
+        .siblings()
+        .find("button")
+        .click()
+        .get("ul.rs-facet-list")
+        .as("facetList");
+
+      cy.get("@facetList").within($facetList => {
+        cy.contains("open");
+        cy.contains("authenticated").should("not.exist");
+      });
+    });
+
+    it("should display collection items grid", () => {
+      cy.get(".rs-result-list.photo-grid").within($grid => {
+        cy.getByTestId("photo-box").within($photoBox => {
+          cy.getLinkIncludesPath("/items");
+          cy.get("img");
+          cy.getByTestId("title-photo-box")
+            .find("a")
+            .should("not.be.empty");
+        });
+      });
+    });
+
+    it("should update content with search within collection", () => {
+      const searchTerms = ["kingdoms", "Guinea"];
+
+      cy.get("input.rs-search-input")
+        .as("searchBox")
+        .type(searchTerms[0]);
+      cy.wait(3000); // Account for debounce setting
+      cy.get(".rs-result-list article")
+        .first()
+        .as("firstResult")
+        .contains(searchTerms[0]);
+
+      cy.get("@searchBox")
+        .clear()
+        .type(searchTerms[1]);
+      cy.wait(3000);
+      cy.get("@firstResult").contains(searchTerms[1]);
+    });
+
+    it("should open Item Details page from collections grid", () => {
+      cy.get(".rs-result-list.photo-grid").within($grid => {
+        cy.get("article")
+          .first()
+          .find("h4 a")
+          .then($a => {
+            const txt = $a.text();
+            cy.contains(txt).click();
+            cy.location("pathname").should("include", "/items");
+            cy.contains("h4", txt);
+          });
+      });
+    });
+
+    context("Facet/filtering", () => {
+      beforeEach(function() {
+        //Get the first result;
+        cy.get(".rs-result-list article")
+          .first()
+          .invoke("text")
+          .as("txt");
+        //Get the number of search results text E.g., 113 results in 10 ms.
+        cy.get(".rs-results-info")
+          .invoke("text")
+          .as("resultsTxt");
+      });
+
+      it("should filter on an example facet (based on Location)", function() {
+        cy.getByTestId("button-filter-toggle").click();
+        cy.getByTestId("facets-sidebar").within($sidebar => {
+          cy.contains("Location")
+            .siblings()
+            .find("button")
+            .click();
+          cy.get(".rs-facet-list")
+            .contains("England--London")
+            .click();
+        });
+
+        cy.wait(3000);
+        // Check for updates
+        cy.get(".rs-result-list article")
+          .first()
+          .find("h4")
+          .should("not.have.text", this.txt);
+        cy.get(".rs-results-info").should("not.have.text", this.resultsTxt);
+
+        // Clear the filter by clicking on the filter link
+        cy.get(".rs-selected-filters a")
+          .first()
+          .click();
+        cy.wait(3000);
+        cy.get(".rs-result-list article")
+          .first()
+          .find("h4")
+          .should("have.text", this.txt);
+      });
+    });
+  });
+
+  context("Authenticated user", () => {
+    const authenticatedRoute =
+      "/collections/17a5d121-2bc2-4942-aa48-34ac86f3b83d";
+
+    it("displays authenticated Work content when logged in", () => {
+      cy.setSSOToken();
+      cy.visitRouteLoggedIn(authenticatedRoute);
+      cy.contains("h2", "University Theatre Production Photographs");
+    });
+    it("redirects an authenticated Work screen when not logged in as authenticated user", () => {
+      cy.visit(authenticatedRoute);
+      cy.contains("Item Details").should("not.exist");
+      cy.get("h2").contains("Page Not Found");
+    });
+  });
+});

--- a/cypress/integration/collections/view_page_spec.js
+++ b/cypress/integration/collections/view_page_spec.js
@@ -1,7 +1,5 @@
 /// <reference types="cypress" />
 
-//const jwt = require("jsonwebtoken");
-
 describe("Collections View page", () => {
   context("Anonymous user", () => {
     beforeEach(() => {
@@ -39,7 +37,7 @@ describe("Collections View page", () => {
     it("should display sidebar", () => {
       cy.get("#sidebar").within($sidebar => {
         cy.contains("h3", "Collection Description");
-        cy.contains("p");
+        cy.contains("p", "113 antique maps of Africa");
       });
     });
 

--- a/cypress/integration/search_page_spec.js
+++ b/cypress/integration/search_page_spec.js
@@ -54,7 +54,7 @@ describe("Search page", () => {
     it("should display search results grid", () => {
       cy.get(".rs-result-list.photo-grid").within($grid => {
         // Default page load results
-        cy.get("article").should("have.length", 12);
+        cy.get("article").should("have.length", 24);
         cy.getByTestId("photo-box").within($photoBox => {
           cy.getLinkIncludesPath("/items");
           cy.get("img");

--- a/src/components/Collection/Collection.js
+++ b/src/components/Collection/Collection.js
@@ -210,7 +210,7 @@ const Collection = () => {
                   URLParams={false}
                 />
 
-                <SelectedFilters />
+                <SelectedFilters className="rs-selected-filters" />
 
                 <FiltersShowHideButton
                   showSidebar={showSidebar}


### PR DESCRIPTION
Added E2E test on collection view page for Authorized and Anonymous users.

<img width="533" alt="Screen Shot 2020-03-31 at 3 57 59 PM" src="https://user-images.githubusercontent.com/14085957/78074517-7c742180-7368-11ea-858a-931c9cb74c77.png">
