### PR TITLE
Bug fix for pagination url

### DIFF
--- a/src/components/Collection/Collection.js
+++ b/src/components/Collection/Collection.js
@@ -223,7 +223,7 @@ const Collection = () => {
                   queryFormat="or"
                   placeholder="Search within collection"
                   showFilter={true}
-                  URLParams={false}
+                  URLParams={true}
                 />
 
                 <SelectedFilters className="rs-selected-filters" />
@@ -251,6 +251,7 @@ const Collection = () => {
                     pagination: "rs-pagination",
                     resultsInfo: "rs-results-info"
                   }}
+                  URLParams={true}
                   sortOptions={sortOptions}
                   defaultSortOption={"Sort By Relevancy"}
                 />


### PR DESCRIPTION
Added the fix to show page number in the url.
<img width="888" alt="Screen Shot 2020-04-09 at 1 02 34 PM" src="https://user-images.githubusercontent.com/14085957/78926255-677f4880-7a62-11ea-8b83-d2322f202fe4.png">
