### PR TITLE
Bump react-media-player from 1.0.1 to 1.0.4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2486,9 +2486,9 @@
       "dev": true
     },
     "@nulib/react-media-player": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.0.1.tgz",
-      "integrity": "sha512-LqfkO9xUV8XxiJelpEkzfBOzuDkMD5a29hqVQVi7Ep9QWdJmheZn3jM1BXJ0nRvUhnTxpOJoQ0rjMPQwGQH6oA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.0.4.tgz",
+      "integrity": "sha512-Mauw08oQJ1J+RgtgBkjJU6Ug+KHI3oXrsgwIdgrKyg2P+5BeEzHbzSgoZFCMsJqUKJzA21ztgVeMe1R+LeRMtA==",
       "requires": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
-    "@nulib/react-media-player": "^1.0.1",
+    "@nulib/react-media-player": "^1.0.4",
     "@reglendo/canvas2image": "^1.0.5-2",
     "@samvera/image-downloader": "^1.1.0",
     "cookie": "^0.4.0",


### PR DESCRIPTION
## Summary 
Bumps react media player from version 1.0.1 to 1.0.4

![image](https://user-images.githubusercontent.com/7376450/136968589-b4ae9465-0ddc-4992-9999-ac0fd79b87f8.png)

## Specific Changes in this PR
- Various style refinements for tabs, item labels
- Addition of pure CSS icons to navigator cues
- Updates media item **Now Playing** text to a more inclusive **Active Item**
- Updates font on work label

## Steps to Test
1. `npm install @nulib/react-media-player `
2. `npm run start:use-staging-data`
2. Navigate to Video or Sound work and review player.

Also please let developers know if there are any special instructions to test this in the development environment. 