### PR TITLE
Make Collection JSON LD type validate by removing thumbnail property

### DIFF
--- a/src/services/google-structured-data.js
+++ b/src/services/google-structured-data.js
@@ -32,7 +32,6 @@ export function loadCollectionStructuredData(collection, pathname) {
     name: collection.title,
     url: `${productionUrl}${pathname}`,
     ...(collection.description && { description: collection.description }),
-    thumbnail: collection.representativeImage?.url,
   };
 
   return obj;

--- a/src/services/google-structured-data.test.js
+++ b/src/services/google-structured-data.test.js
@@ -40,7 +40,6 @@ describe("collection structured data", () => {
     expect(obj).toHaveProperty("name");
     expect(obj).toHaveProperty("description");
     expect(obj).toHaveProperty("url");
-    expect(obj).toHaveProperty("thumbnail");
   });
 
   it("does not add empty values", () => {


### PR DESCRIPTION
## Summary 
Remove property `thumbnail` from JSON LD type `Collection` which was invalidating against Google's Rich Results SEO.
