### PR TITLE
Fix date on citations tab

### DIFF
--- a/src/components/Work/Tabs/Cite.js
+++ b/src/components/Work/Tabs/Cite.js
@@ -28,7 +28,12 @@ const flexTitle = css`
 `;
 
 const TabsCite = ({ item }) => {
-  const { collection, createDate: [date] = "", descriptiveMetadata, id } = item;
+  const {
+    collection,
+    dateCreated: [date] = "",
+    descriptiveMetadata,
+    id,
+  } = item;
 
   const { ark, identifier, license, title, termsOfUse } = descriptiveMetadata;
 
@@ -69,13 +74,13 @@ const TabsCite = ({ item }) => {
     {
       id: "turabianFormat",
       label: "Chicago/Turabian Format",
-      text: `${libraryUnitLabel}, ${nul}. "${title}", ${collectionTitle} Accessed ${today}. ${itemLink}`,
+      text: `${libraryUnitLabel}, ${nul}. "${title}", ${collectionTitle}.  Accessed ${today}. ${itemLink}`,
       style: {},
     },
     {
       id: "mlaFormat",
       label: "MLA Format",
-      text: `${libraryUnitLabel}, ${nul}. "${title}", ${collectionTitle} ${date}. ${window.location.origin}/items/${id}`,
+      text: `${libraryUnitLabel}, ${nul}. "${title}", ${collectionTitle}. ${date}. ${window.location.origin}/items/${id}`,
       style: {},
     },
     {


### PR DESCRIPTION
## Summary 

We lost the date (should be `dateCreated` and not `createDate`) when we launched Fen. Also noticed a few periods (.) missing. 

For reference, here is what the citations tab should look like:
https://github.com/nulib/repodev_planning_and_docs/issues/1488

Compared to after migration: 
https://github.com/nulib/digital-collections/pull/625


## Specific Changes in this PR
- Use date created on citations tab
- Small punctuation fixes

<img width="730" alt="Screen Shot 2022-10-11 at 2 43 02 PM" src="https://user-images.githubusercontent.com/6372022/195194478-4754148c-1350-4a58-abe3-3fb16042c992.png">


## Steps to Test

- Look at citations tab. (work must have necessary fields filled out (title, admin set, date created, etc....)