### PR TITLE
Increase number of Collections displaying on Collections List page

### DIFF
--- a/src/components/Collection/List.js
+++ b/src/components/Collection/List.js
@@ -17,7 +17,7 @@ const CollectionList = () => {
   }, []);
 
   async function getCollections() {
-    let response = await getAllCollections(100);
+    let response = await getAllCollections(250);
 
     // Prep the data for PhotoGrid
     let allCollections = prepPhotoGridItems(


### PR DESCRIPTION
## Summary 
Update Collection List page to display up to 250 results instead of capping at 100

## Specific Changes in this PR
- Updated the query to return 250 instead of 100 records

## Steps to Test
View "All Collections" page, and notice all results are displaying
